### PR TITLE
[SPORK-82] Delta Pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Search:
 * [Quiescence search](https://www.chessprogramming.org/Quiescence_Search)
 * [Iterative deepening](https://www.chessprogramming.org/Iterative_Deepening)
 * [Null move pruning](https://www.chessprogramming.org/Null_Move_Pruning)
+* [Delta pruning](https://www.chessprogramming.org/Delta_Pruning)
 * [Aspiration windows](https://www.chessprogramming.org/Aspiration_Windows)
 * [Transposition tables with Zobrist hashing](https://mediocrechess.blogspot.com/2007/01/guide-transposition-tables.html)
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Communication:
 
 ### Engines
 
+* [cpw-engine](https://github.com/nescitus/cpw-engine)
 * [Black Marlin](https://github.com/jnlt3/blackmarlin?tab=readme-ov-file#efficiently-updatable-neural-networks)
 * [Theodora](https://github.com/yigitkucuk/Theodora/blob/main/main.py)
 * [black_numba](https://github.com/Avo-k/black_numba)

--- a/config.yml
+++ b/config.yml
@@ -5,8 +5,9 @@ SearcherConfig:
   max_depth: 6 # maximum depth for negamax search
   mode: SINGLE_PROCESS # mode of search, choice of: SINGLE_PROCESS, LAZY_SMP
   enable_null_move_pruning: True # flag to enable null move pruning, i.e. checking for a beta-cutoff by passing our turn
+  enable_delta_pruning: True # flag to enable delta pruning, i.e. prune capturing moves that do not raise alpha in quiescence search.
   enable_transposition_table: False # flag to enable position cache, so positions are not evaluated twice
-  enable_aspiration_windows: True # flag to enable aspiration windows, i.e. doing a smaller window search around the score from previous iteration of iterative deepneing.
+  enable_aspiration_windows: True # flag to enable aspiration windows, i.e. doing a smaller window search around the score from previous iteration of iterative deepening.
 
 # Current time management strategy is alloted_move_time = time_weight * current_time + increment_weight * increment
 TimeManagerConfig:

--- a/sporkfish/board/board.py
+++ b/sporkfish/board/board.py
@@ -127,6 +127,16 @@ class Board(ABC):
         pass
 
     @abstractmethod
+    def is_en_passant(self, move: chess.Move) -> bool:
+        """
+        Check if the move made is an en passant move.
+
+        :return: True if the move is an en passant move, false otherwise.
+        :rtype: bool
+        """
+        pass
+
+    @abstractmethod
     def is_check(self) -> bool:
         """
         Check if the current side to move is in check.

--- a/sporkfish/board/board_py_chess.py
+++ b/sporkfish/board/board_py_chess.py
@@ -16,6 +16,7 @@ class BoardPyChess(Board):
         """
         self.board = chess.Board()
 
+    # --- Board mutators ---
     def push(self, move: chess.Move) -> None:
         """
         Apply the given move to the board.
@@ -46,6 +47,7 @@ class BoardPyChess(Board):
         """
         self.board.push_uci(move)
 
+    # --- Board information ---
     @property
     def turn(self) -> chess.Color:
         """
@@ -117,6 +119,15 @@ class BoardPyChess(Board):
         :rtype: bool
         """
         return self.board.is_capture(move)
+
+    def is_en_passant(self, move: chess.Move) -> bool:
+        """
+        Check if the move made is an en passant move.
+
+        :return: True if the move is an en passant move, false otherwise.
+        :rtype: bool
+        """
+        return self.board.is_en_passant(move)
 
     def is_check(self) -> bool:
         """

--- a/sporkfish/evaluator.py
+++ b/sporkfish/evaluator.py
@@ -18,25 +18,25 @@ class Evaluator:
     """
 
     MG_PIECE_VALUES = {
-        chess.PAWN: 82,
-        chess.KNIGHT: 337,
-        chess.BISHOP: 365,
-        chess.ROOK: 477,
-        chess.QUEEN: 1025,
-        chess.KING: 12000,
+        chess.PAWN: 82.0,
+        chess.KNIGHT: 337.0,
+        chess.BISHOP: 365.0,
+        chess.ROOK: 477.0,
+        chess.QUEEN: 1025.0,
+        chess.KING: 12000.0,
     }
 
     EG_PIECE_VALUES = {
-        chess.PAWN: 94,
-        chess.KNIGHT: 281,
-        chess.BISHOP: 297,
-        chess.ROOK: 512,
-        chess.QUEEN: 936,
-        chess.KING: 12000,
+        chess.PAWN: 94.0,
+        chess.KNIGHT: 281.0,
+        chess.BISHOP: 297.0,
+        chess.ROOK: 512.0,
+        chess.QUEEN: 936.0,
+        chess.KING: 12000.0,
     }
 
     # Delta pruning margin for searcher, evaluator dependent
-    DELTA = 200
+    DELTA = 200.0
 
     # fmt: off
 

--- a/sporkfish/evaluator.py
+++ b/sporkfish/evaluator.py
@@ -12,13 +12,31 @@ class Evaluator:
     A class responsible for evaluating the chess position.
 
     Methods:
-    - __init__():
-        Initialize the Evaluator.
-
     - evaluate(board: Board) -> float:
         Evaluate the chess position based on material and piece-square tables.
 
     """
+
+    MG_PIECE_VALUES = {
+        chess.PAWN: 82,
+        chess.KNIGHT: 337,
+        chess.BISHOP: 365,
+        chess.ROOK: 477,
+        chess.QUEEN: 1025,
+        chess.KING: 12000,
+    }
+
+    EG_PIECE_VALUES = {
+        chess.PAWN: 94,
+        chess.KNIGHT: 281,
+        chess.BISHOP: 297,
+        chess.ROOK: 512,
+        chess.QUEEN: 936,
+        chess.KING: 12000,
+    }
+
+    # Delta pruning margin for searcher, evaluator dependent
+    DELTA = 200
 
     # fmt: off
 

--- a/sporkfish/searcher.py
+++ b/sporkfish/searcher.py
@@ -177,7 +177,7 @@ class Searcher:
             return (
                 chess.PAWN
                 if board.is_en_passant(move)
-                else board.piece_at(move.to_square).piece_type
+                else board.piece_at(move.to_square).piece_type  # type: ignore
             )
 
         for move in legal_moves:

--- a/sporkfish/searcher.py
+++ b/sporkfish/searcher.py
@@ -183,8 +183,8 @@ class Searcher:
         for move in legal_moves:
             # Delta pruning
             # Rationale: if our position is such that:
-            # evaluation + captured piece value + safety margin (delta)
-            # doesn't exceed what I can already guarantee, then don't do Quiescence search for this branch.
+            # evaluation + captured piece value + safety margin (delta) doesn't exceed what I can already guarantee,
+            # then there is no point to continue the search for this branch.
             # The safety margin leaves some room for searching for sacrifices,
             # i.e. taking a pawn down a rook usually will not help but taking a bishop down a rook may help.
             # The delta value should be tuned based on piece values of the evaluator.

--- a/sporkfish/searcher.py
+++ b/sporkfish/searcher.py
@@ -52,6 +52,7 @@ class SearcherConfig(Configurable):
         max_depth: int = 5,
         mode: SearchMode = SearchMode.SINGLE_PROCESS,
         enable_null_move_pruning: bool = True,
+        enable_delta_pruning: bool = True,
         enable_transposition_table: bool = False,
         enable_aspiration_windows: bool = True,
     ) -> None:
@@ -59,6 +60,7 @@ class SearcherConfig(Configurable):
         # TODO: register the constructor function in yaml loader instead.
         self.mode = mode if isinstance(mode, SearchMode) else SearchMode(mode)
         self.enable_null_move_pruning = enable_null_move_pruning
+        self.enable_delta_pruning = enable_delta_pruning
         self.enable_transposition_table = enable_transposition_table
         self.enable_aspiration_windows = enable_aspiration_windows
 
@@ -160,6 +162,7 @@ class Searcher:
 
         if stand_pat >= beta:
             return beta
+
         if alpha < stand_pat:
             alpha = stand_pat
 
@@ -169,7 +172,34 @@ class Searcher:
             reverse=True,
         )
 
+        # Assuming the input move is a capturing move, returns the captured piece
+        def captured_piece(board: Board, move: chess.Move) -> chess.PieceType:
+            return (
+                chess.PAWN
+                if board.is_en_passant(move)
+                else board.piece_at(move.to_square).piece_type
+            )
+
         for move in legal_moves:
+            # Delta pruning
+            # Rationale: if our position is such that:
+            # evaluation + captured piece value + safety margin (delta)
+            # doesn't exceed what I can already guarantee, then don't do Quiescence search for this branch.
+            # The safety margin leaves some room for searching for sacrifices,
+            # i.e. taking a pawn down a rook usually will not help but taking a bishop down a rook may help.
+            # The delta value should be tuned based on piece values of the evaluator.
+            # TODO: consider add check for late endgame - it should not be enabled there because
+            # transitions into won endgames made at the expense of some material will no longer be considered
+            # However we might remedy this directly with endgame tablebases.
+            if (
+                self._config.enable_delta_pruning
+                and stand_pat
+                + self.evaluator.MG_PIECE_VALUES[captured_piece(board, move)]
+                + self.evaluator.DELTA
+                < alpha
+            ):
+                continue
+
             board.push(move)
             score = -self._quiescence(board, depth - 1, -beta, -alpha)
             board.pop()
@@ -218,7 +248,7 @@ class Searcher:
         self._statistics.increment()
 
         # Base case: devolve to quiescence search
-        # We currently only expect max 4 captures to reach a quiet position
+        # We currently only expect at most 4 captures to reach a quiet position
         # This is not ideal, but otherwise the search becomes incredibly slow
         if depth == 0:
             return self._quiescence(board, 4, alpha, beta)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -53,10 +53,10 @@ class TestValidMove:
 @pytest.mark.parametrize(
     ("fen_string", "max_depth"),
     [
-        # (board_setup["white"]["mid"], 4),
-        # (board_setup["white"]["open"], 5),
-        (board_setup["black"]["mid"], 7),
-        # (board_setup["black"]["end"], 6),
+        (board_setup["white"]["mid"], 4),
+        (board_setup["white"]["open"], 5),
+        (board_setup["black"]["mid"], 6),
+        (board_setup["black"]["end"], 6),
     ],
 )
 class TestPerformance:
@@ -93,49 +93,49 @@ class TestPerformance:
 
         stats.strip_dirs().sort_stats("tottime").print_stats(10)
 
-    @pytest.mark.slow
-    def test_perf_base(self, fen_string: str, max_depth: int) -> None:
-        """Performance test base"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-        )
+    # @pytest.mark.slow
+    # def test_perf_base(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test base"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with transposition table"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_transposition_table=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with transposition table"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_transposition_table=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with null move pruning"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with null move pruning"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_null_move_pruning=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with aspiration windows"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_aspiration_windows=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with aspiration windows"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_aspiration_windows=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_delta_pruning(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with aspiration windows"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_delta_pruning=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_delta_pruning(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with aspiration windows"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_delta_pruning=True,
+    #     )
 
     @pytest.mark.slow
     def test_perf_combined(self, fen_string: str, max_depth: int) -> None:
@@ -144,6 +144,7 @@ class TestPerformance:
             fen=fen_string,
             max_depth=max_depth,
             enable_null_move_pruning=True,
+            enable_delta_pruning=True,
             enable_aspiration_windows=True,
         )
 

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -101,32 +101,32 @@ class TestPerformance:
             max_depth=max_depth,
         )
 
-    # @pytest.mark.slow
-    # def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with transposition table"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_transposition_table=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with transposition table"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_transposition_table=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with null move pruning"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_null_move_pruning=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with null move pruning"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with aspiration windows"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_aspiration_windows=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with aspiration windows"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_aspiration_windows=True,
+        )
 
     @pytest.mark.slow
     def test_perf_delta_pruning(self, fen_string: str, max_depth: int) -> None:
@@ -137,15 +137,15 @@ class TestPerformance:
             enable_delta_pruning=True,
         )
 
-    # @pytest.mark.slow
-    # def test_perf_combined(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with combined general performance config on"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_null_move_pruning=True,
-    #         enable_aspiration_windows=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_combined(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with combined general performance config on"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+            enable_aspiration_windows=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -198,7 +198,7 @@ class TestConsistency:
         )
 
     def test_delta_pruning_consistency(self, fen_string: str, max_depth: int):
-        "Tests base searcher and null move pruning on return the same score and bestmove"
+        "Tests base searcher and delta pruning on return the same score and bestmove"
         self._run_consistency_test(
             fen=fen_string, max_depth=max_depth, enable_delta_pruning=True
         )

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -93,49 +93,49 @@ class TestPerformance:
 
         stats.strip_dirs().sort_stats("tottime").print_stats(10)
 
-    # @pytest.mark.slow
-    # def test_perf_base(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test base"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #     )
+    @pytest.mark.slow
+    def test_perf_base(self, fen_string: str, max_depth: int) -> None:
+        """Performance test base"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with transposition table"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_transposition_table=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with transposition table"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_transposition_table=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with null move pruning"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_null_move_pruning=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with null move pruning"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with aspiration windows"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_aspiration_windows=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with aspiration windows"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_aspiration_windows=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_delta_pruning(self, fen_string: str, max_depth: int) -> None:
-    #     """Performance test with aspiration windows"""
-    #     self._run_perf_analytics(
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_delta_pruning=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_delta_pruning(self, fen_string: str, max_depth: int) -> None:
+        """Performance test with aspiration windows"""
+        self._run_perf_analytics(
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_delta_pruning=True,
+        )
 
     @pytest.mark.slow
     def test_perf_combined(self, fen_string: str, max_depth: int) -> None:

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -12,6 +12,7 @@ def _searcher_with_fen(
     fen: str,
     max_depth: int = 3,
     enable_null_move_pruning=False,
+    enable_delta_pruning=False,
     enable_transposition_table=False,
     enable_aspiration_windows=False,
 ):
@@ -22,6 +23,7 @@ def _searcher_with_fen(
         SearcherConfig(
             max_depth,
             enable_null_move_pruning=enable_null_move_pruning,
+            enable_delta_pruning=enable_delta_pruning,
             enable_transposition_table=enable_transposition_table,
             enable_aspiration_windows=enable_aspiration_windows,
         ),
@@ -51,10 +53,10 @@ class TestValidMove:
 @pytest.mark.parametrize(
     ("fen_string", "max_depth"),
     [
-        (board_setup["white"]["mid"], 4),
-        (board_setup["white"]["open"], 5),
-        (board_setup["black"]["mid"], 6),
-        (board_setup["black"]["end"], 6),
+        # (board_setup["white"]["mid"], 4),
+        # (board_setup["white"]["open"], 5),
+        (board_setup["black"]["mid"], 7),
+        # (board_setup["black"]["end"], 6),
     ],
 )
 class TestPerformance:
@@ -69,6 +71,7 @@ class TestPerformance:
         fen: str,
         max_depth: int,
         enable_null_move_pruning: bool = False,
+        enable_delta_pruning: bool = False,
         enable_transposition_table: bool = False,
         enable_aspiration_windows: bool = False,
     ) -> None:
@@ -81,6 +84,7 @@ class TestPerformance:
             fen,
             max_depth,
             enable_null_move_pruning=enable_null_move_pruning,
+            enable_delta_pruning=enable_delta_pruning,
             enable_transposition_table=enable_transposition_table,
             enable_aspiration_windows=enable_aspiration_windows,
         )
@@ -97,42 +101,51 @@ class TestPerformance:
             max_depth=max_depth,
         )
 
-    @pytest.mark.slow
-    def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with transposition table"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_transposition_table=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_transposition_table(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with transposition table"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_transposition_table=True,
+    #     )
+
+    # @pytest.mark.slow
+    # def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with null move pruning"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_null_move_pruning=True,
+    #     )
+
+    # @pytest.mark.slow
+    # def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with aspiration windows"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_aspiration_windows=True,
+    #     )
 
     @pytest.mark.slow
-    def test_perf_null_move_pruning(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with null move pruning"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-        )
-
-    @pytest.mark.slow
-    def test_perf_aspiration_windows(self, fen_string: str, max_depth: int) -> None:
+    def test_perf_delta_pruning(self, fen_string: str, max_depth: int) -> None:
         """Performance test with aspiration windows"""
         self._run_perf_analytics(
             fen=fen_string,
             max_depth=max_depth,
-            enable_aspiration_windows=True,
+            enable_delta_pruning=True,
         )
 
-    @pytest.mark.slow
-    def test_perf_combined(self, fen_string: str, max_depth: int) -> None:
-        """Performance test with combined general performance config on"""
-        self._run_perf_analytics(
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-            enable_aspiration_windows=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_combined(self, fen_string: str, max_depth: int) -> None:
+    #     """Performance test with combined general performance config on"""
+    #     self._run_perf_analytics(
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_null_move_pruning=True,
+    #         enable_aspiration_windows=True,
+    #     )
 
 
 @pytest.mark.parametrize(
@@ -156,6 +169,7 @@ class TestConsistency:
         fen: str,
         max_depth: int,
         enable_null_move_pruning: bool = False,
+        enable_delta_pruning: bool = False,
         enable_transposition_table: bool = False,
         enable_aspiration_windows: bool = False,
     ):
@@ -164,6 +178,7 @@ class TestConsistency:
             fen,
             max_depth,
             enable_null_move_pruning=enable_null_move_pruning,
+            enable_delta_pruning=enable_delta_pruning,
             enable_transposition_table=enable_transposition_table,
             enable_aspiration_windows=enable_aspiration_windows,
         )
@@ -180,6 +195,12 @@ class TestConsistency:
         "Tests base searcher and null move pruning on return the same score and bestmove"
         self._run_consistency_test(
             fen=fen_string, max_depth=max_depth, enable_null_move_pruning=True
+        )
+
+    def test_delta_pruning_consistency(self, fen_string: str, max_depth: int):
+        "Tests base searcher and null move pruning on return the same score and bestmove"
+        self._run_consistency_test(
+            fen=fen_string, max_depth=max_depth, enable_delta_pruning=True
         )
 
     def test_aspiration_windows_consistency(self, fen_string: str, max_depth: int):


### PR DESCRIPTION
Currently only has effect where the evaluator is called MANY times, e.g. at depth 7 for [r1b2rk1/ppq2ppp/3bpn2/3pP3/8/2PB2B1/PP1N1PPP/R2QK2R b KQ - 0 11]:
* test_perf_base         397709282 function calls (396717202 primitive calls) in 132.203 seconds
* test_perf_delta_pruning          352045446 function calls (351229716 primitive calls) in 116.375 seconds
* test_perf_combined  76599863 function calls (76421728 primitive calls) in **25.200** seconds - pretty amazing!

Otherwise it keeps the runtime about the same, though evaluator is called less (this means the extra time to calculate the piece type of captured pieces becomes the bottleneck, I think): [r1b2rk1/ppqn1pbp/6p1/3pp3/7B/2PB1N2/PP3PPP/R2QR1K1 w - - 0 16], depth 4:

```
test_perf_base        51991010 function calls (51883437 primitive calls) in 16.572 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   102263    2.904    0.000    7.676    0.000 evaluator.py:208(evaluate)
```

```
test_perf_delta_pruning  45108764 function calls (45028818 primitive calls) in 15.887 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    74636    2.374    0.000    6.210    0.000 evaluator.py:208(evaluate)
```
