### PR TITLE
[SPORK-101] Improve MVV-LVA performance

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -12,8 +12,6 @@ jobs:
     defaults:
       run:
         working-directory: ./
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       # -- Setup --
@@ -30,10 +28,10 @@ jobs:
       - name: Run docker container
         run: docker run --name sporkfish-container -d -it sporkfish-image
       # -- Inspect code/tests --
-      - name: Check typing (mypy)
-        run: docker exec sporkfish-container mypy --install-types --non-interactive
       - name: Check tests (pytest)
         run: docker exec sporkfish-container pytest -sv
+      - name: Check typing (mypy)
+        run: docker exec sporkfish-container mypy --install-types --non-interactive
       - name: Check code format (black)
         run: docker exec sporkfish-container black --check .
       - name: Check imports format (isort)

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,14 +7,14 @@ on:
   workflow_dispatch:
 
 jobs:
-
   setup_and_run_tests:
+    name: setup_and_run_tests
     defaults:
       run:
         working-directory: ./
-
+    strategy:
+      fail-fast: false
     runs-on: ubuntu-latest
-
     steps:
       # -- Setup --
       - name: Checkout code

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -9,8 +9,6 @@ jobs:
   deploy_container:
     name: deploy_container
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -7,8 +7,10 @@ on:
 jobs:
 
   deploy_container:
+    name: deploy_container
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/sporkfish/evaluator.py
+++ b/sporkfish/evaluator.py
@@ -235,21 +235,22 @@ class Evaluator:
         # - Chess board implements A1 as first element, H8 as last
         # - Piece square table implements A8 as first element, H1 as last element
         flip: Callable[[int, int, chess.Color]] = (
-            lambda square, flipped_sq, color: square if not color else flipped_sq
+            lambda square, flipped_square, color: square if not color else flipped_square
         )
 
         phase = 0
 
         for square in self.SQUARES:
             # square ^ 56 flips the board vertically to match alignment of PSQT
-            flipped_sq = self.VERTICALLY_FLIPPED_SQUARES[square]
-            piece = board.piece_at(flipped_sq)
+            flipped_square = self.VERTICALLY_FLIPPED_SQUARES[square]
+            piece = board.piece_at(flipped_square)
             if piece:
+                aligned_square = flip(square, flipped_square, piece.color)
                 mg[piece.color] += self.MG_PESTO[piece.piece_type][
-                    flip(square, flipped_sq, piece.color)
+                    aligned_square
                 ]
                 eg[piece.color] += self.EG_PESTO[piece.piece_type][
-                    flip(square, flipped_sq, piece.color)
+                    aligned_square
                 ]
                 phase += self.PHASES[piece.piece_type]
 

--- a/sporkfish/searcher/minimax.py
+++ b/sporkfish/searcher/minimax.py
@@ -31,9 +31,9 @@ class MiniMaxVariants(Searcher, ABC):
         self,
         evaluator: Evaluator,
         move_order: MoveOrder,
-        config: SearcherConfig = SearcherConfig(),
+        searcher_config: SearcherConfig = SearcherConfig(),
     ) -> None:
-        super().__init__(config)
+        super().__init__(searcher_config)
 
         if self._searcher_config.enable_transposition_table:
             self._zobrist_hash = ZobristHasher()

--- a/sporkfish/searcher/minimax.py
+++ b/sporkfish/searcher/minimax.py
@@ -35,7 +35,7 @@ class MiniMaxVariants(Searcher, ABC):
     ) -> None:
         super().__init__(config)
 
-        if self._config.enable_transposition_table:
+        if self._searcher_config.enable_transposition_table:
             self._zobrist_hash = ZobristHasher()
             self._transposition_table = TranspositionTable(self._dict)
             logging.info("Enabled transposition table in search.")
@@ -79,7 +79,7 @@ class MiniMaxVariants(Searcher, ABC):
         :return: A tuple containing the score and the best move found during the search.
         :rtype: Tuple[float, chess.Move]
         """
-        if self._config.enable_aspiration_windows and depth > 1:
+        if self._searcher_config.enable_aspiration_windows and depth > 1:
             # Aspiration window size: 50 centipawn is worth about 1/2 of a pawn in our eval function
             # We leave configuration for this to another PR
             window_size = 50
@@ -151,7 +151,7 @@ class MiniMaxVariants(Searcher, ABC):
             # transitions into won endgames made at the expense of some material will no longer be considered
             # However we might remedy this directly with endgame tablebases.
             if (
-                self._config.enable_delta_pruning
+                self._searcher_config.enable_delta_pruning
                 and stand_pat
                 + self.evaluator.MG_PIECE_VALUES[captured_piece(board, move)]
                 + self.evaluator.DELTA
@@ -225,7 +225,7 @@ class MiniMaxVariants(Searcher, ABC):
         score = -float("inf")
         move = chess.Move.null()
 
-        for depth in range(1, self._config.max_depth + 1):
+        for depth in range(1, self._searcher_config.max_depth + 1):
             new_board = copy.deepcopy(board)
 
             alpha = -float("inf")

--- a/sporkfish/searcher/move_ordering.py
+++ b/sporkfish/searcher/move_ordering.py
@@ -47,13 +47,10 @@ class MvvLvaHeuristic(MoveOrder):
             int: The heuristic value of the capturing move based on the value of the captured piece.
         """
 
-        captured_piece = board.piece_at(move.to_square)
-        moving_piece = board.piece_at(move.from_square)
-
         if (
-            captured_piece is not None
-            and moving_piece is not None
-            and board.is_capture(move)
+            board.is_capture(move)
+            and (captured_piece := board.piece_at(move.to_square))
+            and (moving_piece := board.piece_at(move.from_square))
         ):
             return self._MVV_LVA[captured_piece.piece_type - 1][
                 moving_piece.piece_type - 1

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -14,9 +14,9 @@ class NegamaxSp(MiniMaxVariants):
         self,
         evaluator: Evaluator,
         move_order: MoveOrder,
-        config: SearcherConfig = SearcherConfig(),
+        searcher_config: SearcherConfig = SearcherConfig(),
     ) -> None:
-        super().__init__(evaluator, move_order, config)
+        super().__init__(evaluator, move_order, searcher_config)
 
     def _negamax(
         self,
@@ -40,7 +40,7 @@ class NegamaxSp(MiniMaxVariants):
         value = -float("inf")
 
         # Probe the transposition table for an existing entry
-        if self._config.enable_transposition_table:
+        if self._searcher_config.enable_transposition_table:
             hash_value = self._zobrist_hash.hash(board)
             tt_entry = self._transposition_table.probe(hash_value, depth)
             if tt_entry:
@@ -56,7 +56,7 @@ class NegamaxSp(MiniMaxVariants):
 
         # Null move pruning - reduce the search space by trying a null move,
         # then seeing if the score of the subtree search is still high enough to cause a beta cutoff
-        if self._config.enable_null_move_pruning:
+        if self._searcher_config.enable_null_move_pruning:
             if self._null_move_pruning(board, depth, alpha, beta):
                 return beta
 
@@ -75,7 +75,7 @@ class NegamaxSp(MiniMaxVariants):
             if alpha >= beta:
                 break
 
-        if self._config.enable_transposition_table:
+        if self._searcher_config.enable_transposition_table:
             self._transposition_table.store(hash_value, depth, value)
 
         return value
@@ -139,7 +139,7 @@ class NegamaxSp(MiniMaxVariants):
             if alpha >= beta:
                 break
 
-        if self._config.enable_transposition_table:
+        if self._searcher_config.enable_transposition_table:
             hash_value = self._zobrist_hash.hash(board)
             self._transposition_table.store(hash_value, depth, value)
 

--- a/sporkfish/searcher/negamax_lazy_smp.py
+++ b/sporkfish/searcher/negamax_lazy_smp.py
@@ -17,9 +17,9 @@ class NegaMaxLazySmp(NegamaxSp):
         self,
         evaluator: Evaluator,
         order: MoveOrder,
-        config: SearcherConfig = SearcherConfig(),
+        searcher_config: SearcherConfig = SearcherConfig(),
     ) -> None:
-        super().__init__(evaluator, order, config)
+        super().__init__(evaluator, order, searcher_config)
 
         self._num_processes = os.cpu_count()
         self._pool = ProcessPool(nodes=self._num_processes)

--- a/sporkfish/searcher/searcher.py
+++ b/sporkfish/searcher/searcher.py
@@ -16,16 +16,16 @@ class Searcher(ABC):
     Dynamic best move searching class.
     """
 
-    def __init__(self, config: SearcherConfig = SearcherConfig()) -> None:
+    def __init__(self, searcher_config: SearcherConfig = SearcherConfig()) -> None:
         """
         Initialize the Searcher instance with mutable statistics.
 
-        :param config: Config to use for searching.
-        :type config: SearcherConfig
+        :param searcher_config: Config to use for searching.
+        :type searcher_config: SearcherConfig
         :return: None
         """
 
-        self._config = config
+        self._searcher_config = searcher_config
         self._stats = 0
         self._statistics = Statistics(self._stats)
         self._dict: dict = dict()

--- a/sporkfish/searcher/searcher.py
+++ b/sporkfish/searcher/searcher.py
@@ -10,13 +10,6 @@ from ..evaluator import Evaluator
 from ..statistics import Statistics
 from .searcher_config import SearcherConfig
 
-# _manager = Manager()
-# We explicitly do not lock these and let race conditions happen
-# Locks are too slow, need to consider atomic maps / values later
-# This might cause underestimation of statistics.
-# _dict = _manager.dict()
-# _stats = _manager.Value("i", 0)
-
 
 class Searcher(ABC):
     """

--- a/sporkfish/searcher/searcher.py
+++ b/sporkfish/searcher/searcher.py
@@ -27,12 +27,8 @@ class Searcher(ABC):
         """
         Initialize the Searcher instance with mutable statistics.
 
-        :param evaluator: The chess board evaluator.
-        :type evaluator: evaluator.Evaluator
-        :param max_depth: The maximum search depth for the minimax algorithm. Default is 5.
-        :type max_depth: int
         :param config: Config to use for searching.
-        :type mode: SearcherConfig
+        :type config: SearcherConfig
         :return: None
         """
 
@@ -44,8 +40,6 @@ class Searcher(ABC):
     def _log_info(
         self, elapsed: float, score: float, move: chess.Move, depth: int
     ) -> None:
-        """
-        Some logging description!"""
         fields = {
             "depth": depth,
             # time in ms


### PR DESCRIPTION
Reduces the calls to piece_at. Before:

```
tests/test_searcher.py::TestPerformance::test_perf_base[r1b2rk1/ppq2ppp/3bpn2/3pP3/8/2PB2B1/PP1N1PPP/R2QK2R b KQ - 0 11-6]          87048525 function calls (86843206 primitive calls) in 28.221 seconds
 ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   169782    4.990    0.000   13.048    0.000 evaluator.py:214(evaluate)
 14054764    4.113    0.000    7.579    0.000 __init__.py:725(piece_at)
 14675498    2.798    0.000    2.798    0.000 __init__.py:735(piece_type_at)
```

After

```
tests/test_searcher.py::TestPerformance::test_perf_base[r1b2rk1/ppq2ppp/3bpn2/3pP3/8/2PB2B1/PP1N1PPP/R2QK2R b KQ - 0 11-6]          82706717 function calls (82501398 primitive calls) in 27.367 seconds

   Ordered by: internal time
   List reduced from 156 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   169782    5.015    0.000   13.320    0.000 evaluator.py:214(evaluate)
 11160202    3.322    0.000    6.037    0.000 __init__.py:725(piece_at)
 11780936    2.234    0.000    2.234    0.000 __init__.py:735(piece_type_at)
```