### PR TITLE
[SPORK-70] Incremental Zobrist hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ See any of the following sections to quickly setup your development environment.
 - [Using DevContainer with VSCode](#using-devcontainer-with-vscode)* *recommended*
 - [Using DevContainer with PyCharm](#using-devcontainer-with-pycharm)
 - [Using Github Codespace](#using-github-codespace)
+- [Using native Docker](#using-native-docker)
 
 ### Using DevContainer with VSCode
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Sporkfish is a Python-based chess engine. Chess programming techniques, although
 
 - - - -
 
-## Set-up
+## Setup
 
 See any of the following sections to quickly setup your development environment.
 - [Using DevContainer with VSCode](#using-devcontainer-with-vscode)* *recommended*
@@ -23,8 +23,6 @@ Instructions:
 1. Make sure `Docker Desktop` is up and running.
 2. Open up the Command Palette and run `Dev Containers: Rebuild Container`
 3. The window should reload and you will see `[Dev Container]` in the URL bar as well as on the status bar bottom left of the window to indicate your setup is complete.
-
-This will setup a Docker container to run in Docker Desktop with all the necessary dependencies (python, pip, git, ...) with the correct versions.
 
 ### Using DevContainer with PyCharm
 
@@ -45,13 +43,13 @@ Prerequisites:
 
 Instructions:
 1. In this Github repository, click on the Code dropdown, select Codespace and click `Create`.
-2. Confirm codespace settings, for Machine type select `2-core` (this can be changed later if you require more power)
+2. Confirm codespace settings, for Machine type select `2-core` (this can be changed later if you require more power).
 
-This will setup a Dockeer container to run in Github with all the necessary dependencies (python, pip, git, ...) with the correct versions. An active internet connection will be required for this, and this will use up your monthly allowance for Github codespace.
+An active internet connection will be required for this. This will also use up your monthly allowance for Github codespace.
 
 ### Using native Docker
 
-To quickly set up the environment, you can use docker. From a terminal in the root directory:
+To quickly set up the environment, you can use docker. Pull the code from git and from a terminal in the root directory:
 
 ```
 docker pull kylchiu/sporkfish-dev:latest

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This generates an interactive bash shell for you to run the program in.
 Check out the bot on lichess [here](https://lichess.org/@/Sporkfish)! To run the bot, create a file in the root directory named `api_token.txt`. Add your Lichess bot API token. Then run:
 
 ```
-python3 main.py
+python3 -O main.py
 ```
 
 Once you create a game via your bot account, the bot will automatically play. We currently do not support simultaneous games.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ An active internet connection will be required for this. This will also use up y
 
 ### Using native Docker
 
-To quickly set up the environment, you can use docker. Pull the code from git and from a terminal in the root directory:
+Prerequisites:
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
 ```
 docker pull kylchiu/sporkfish-dev:latest

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ An active internet connection will be required for this. This will also use up y
 Prerequisites:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 
+After cloning the repository, from the root directory, run:
+
 ```
 docker pull kylchiu/sporkfish-dev:latest
 docker build -t kylchiu/sporkfish-dev:latest .

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -154,7 +154,8 @@ class NegamaxSp(MiniMaxVariants):
         if depth >= depth_reduction_factor and not in_check:
             null_move_depth = depth - depth_reduction_factor
             board.push(chess.Move.null())
-            value = -self._negamax(board, null_move_depth, -beta, -alpha)
+            # TODO: check if too expensive to calculate Zobrist state here
+            value = -self._negamax(board, null_move_depth, -beta, -alpha, None)
             board.pop()
             if value >= beta:
                 return True

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -69,7 +69,13 @@ class NegamaxSp(MiniMaxVariants):
         # Recursive search with alpha-beta pruning
         for move in legal_moves:
             # Get captures for futility pruning or transposition table
+            # Get  piece at previous from_square for transposition table
             # This needs to be done prior to changing the board state
+            previous_piece_from_square = (
+                board.piece_at(move.from_square)
+                if self._searcher_config.enable_transposition_table
+                else False
+            )
             capture = (
                 board.is_capture(move)
                 if self._searcher_config.enable_futility_pruning
@@ -94,7 +100,11 @@ class NegamaxSp(MiniMaxVariants):
             # Update the Zobrist hash
             child_zobrist_state = (
                 self._zobrist_hash.incremental_zobrist_hash(
-                    board, move, zobrist_state, captured_piece
+                    board,
+                    move,
+                    zobrist_state,
+                    previous_piece_from_square,
+                    captured_piece,
                 )
                 if self._searcher_config.enable_transposition_table
                 else None
@@ -183,8 +193,13 @@ class NegamaxSp(MiniMaxVariants):
 
         legal_moves = self._ordered_moves(board, board.legal_moves)
         for move in legal_moves:
-            # Get captures for transposition table
+            # Get piece at from_square and captures for transposition table
             # This needs to be done prior to changing the board state
+            previous_piece_from_square = (
+                board.piece_at(move.to_square)
+                if self._searcher_config.enable_transposition_table
+                else False
+            )
             capture = (
                 board.is_capture(move)
                 if self._searcher_config.enable_transposition_table
@@ -201,7 +216,11 @@ class NegamaxSp(MiniMaxVariants):
             # Update the Zobrist hash
             child_zobrist_state = (
                 self._zobrist_hash.incremental_zobrist_hash(
-                    board, move, zobrist_state, captured_piece
+                    board,
+                    move,
+                    zobrist_state,
+                    previous_piece_from_square,
+                    captured_piece,
                 )
                 if self._searcher_config.enable_transposition_table
                 else None

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -92,19 +92,18 @@ class NegamaxSp(MiniMaxVariants):
                 continue
 
             # Update the Zobrist hash
-            child_zobrist_state = self._zobrist_hash.incremental_zobrist_hash(
-                board,
-                move,
-                zobrist_state,
-                captured_piece
+            child_zobrist_state = (
+                self._zobrist_hash.incremental_zobrist_hash(
+                    board, move, zobrist_state, captured_piece
+                )
                 if self._searcher_config.enable_transposition_table
-                else None,
+                else None
             )
+
             child_value = -self._negamax(
                 board, depth - 1, -beta, -alpha, child_zobrist_state
             )
 
-            child_value = -self._negamax(board, depth - 1, -beta, -alpha)
             board.pop()
 
             value = max(value, child_value)
@@ -200,13 +199,12 @@ class NegamaxSp(MiniMaxVariants):
             board.push(move)
 
             # Update the Zobrist hash
-            child_zobrist_state = self._zobrist_hash.incremental_zobrist_hash(
-                board,
-                move,
-                zobrist_state,
-                captured_piece
+            child_zobrist_state = (
+                self._zobrist_hash.incremental_zobrist_hash(
+                    board, move, zobrist_state, captured_piece
+                )
                 if self._searcher_config.enable_transposition_table
-                else None,
+                else None
             )
             child_value = -self._negamax(
                 board, depth - 1, -beta, -alpha, child_zobrist_state

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -106,7 +106,7 @@ class NegamaxSp(MiniMaxVariants):
                     previous_piece_from_square,
                     captured_piece,
                 )
-                if self._searcher_config.enable_transposition_table
+                if zobrist_state
                 else None
             )
 
@@ -223,7 +223,7 @@ class NegamaxSp(MiniMaxVariants):
                     previous_piece_from_square,
                     captured_piece,
                 )
-                if self._searcher_config.enable_transposition_table
+                if zobrist_state
                 else None
             )
             child_value = -self._negamax(

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -69,7 +69,7 @@ class NegamaxSp(MiniMaxVariants):
         # Recursive search with alpha-beta pruning
         for move in legal_moves:
             # Get captures for futility pruning or transposition table
-            # Get  piece at previous from_square for transposition table
+            # Get piece at previous from_square for transposition table
             # This needs to be done prior to changing the board state
             previous_piece_from_square = (
                 board.piece_at(move.from_square)

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -42,7 +42,7 @@ class NegamaxSp(MiniMaxVariants):
         value = -float("inf")
 
         # Probe the transposition table for an existing entry
-        if self._searcher_config.enable_transposition_table:
+        if zobrist_state:
             tt_entry = self._transposition_table.probe(
                 zobrist_state.zobrist_hash, depth
             )
@@ -72,20 +72,15 @@ class NegamaxSp(MiniMaxVariants):
             # Get piece at previous from_square for transposition table
             # This needs to be done prior to changing the board state
             previous_piece_from_square = (
-                board.piece_at(move.from_square)
-                if self._searcher_config.enable_transposition_table
-                else False
+                board.piece_at(move.from_square) if zobrist_state else None
             )
             capture = (
                 board.is_capture(move)
-                if self._searcher_config.enable_futility_pruning
-                or self._searcher_config.enable_transposition_table
+                if self._searcher_config.enable_futility_pruning or zobrist_state
                 else False
             )
             captured_piece = (
-                board.piece_at(move.to_square)
-                if self._searcher_config.enable_transposition_table and capture
-                else None
+                board.piece_at(move.to_square) if zobrist_state and capture else None
             )
 
             board.push(move)
@@ -103,7 +98,7 @@ class NegamaxSp(MiniMaxVariants):
                     board,
                     move,
                     zobrist_state,
-                    previous_piece_from_square,
+                    previous_piece_from_square,  # type: ignore
                     captured_piece,
                 )
                 if zobrist_state
@@ -122,7 +117,7 @@ class NegamaxSp(MiniMaxVariants):
             if alpha >= beta:
                 break
 
-        if self._searcher_config.enable_transposition_table:
+        if zobrist_state:
             self._transposition_table.store(zobrist_state.zobrist_hash, depth, value)
 
         return value
@@ -197,18 +192,11 @@ class NegamaxSp(MiniMaxVariants):
             # Get piece at from_square and captures for transposition table
             # This needs to be done prior to changing the board state
             previous_piece_from_square = (
-                board.piece_at(move.to_square)
-                if self._searcher_config.enable_transposition_table
-                else False
-            )
-            capture = (
-                board.is_capture(move)
-                if self._searcher_config.enable_transposition_table
-                else False
+                board.piece_at(move.to_square) if zobrist_state else None
             )
             captured_piece = (
                 board.piece_at(move.to_square)
-                if self._searcher_config.enable_transposition_table and capture
+                if zobrist_state and board.is_capture(move)
                 else None
             )
 
@@ -220,7 +208,7 @@ class NegamaxSp(MiniMaxVariants):
                     board,
                     move,
                     zobrist_state,
-                    previous_piece_from_square,
+                    previous_piece_from_square,  # type: ignore
                     captured_piece,
                 )
                 if zobrist_state
@@ -240,7 +228,7 @@ class NegamaxSp(MiniMaxVariants):
             if alpha >= beta:
                 break
 
-        if self._searcher_config.enable_transposition_table:
+        if zobrist_state:
             self._transposition_table.store(zobrist_state.zobrist_hash, depth, value)
 
         return value, best_move

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -59,9 +59,10 @@ class NegamaxSp(MiniMaxVariants):
 
         # Null move pruning - reduce the search space by trying a null move,
         # then seeing if the score of the subtree search is still high enough to cause a beta cutoff
-        if self._searcher_config.enable_null_move_pruning:
-            if self._null_move_pruning(board, depth, alpha, beta):
-                return beta
+        if self._searcher_config.enable_null_move_pruning and self._null_move_pruning(
+            board, depth, alpha, beta
+        ):
+            return beta
 
         # Move ordering
         legal_moves = self._ordered_moves(board, board.legal_moves)

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple
 
 import chess
-import numpy as np
 
 from ..board.board import Board
 from ..evaluator import Evaluator

--- a/sporkfish/transposition_table.py
+++ b/sporkfish/transposition_table.py
@@ -1,8 +1,10 @@
 from typing import Dict, Optional
 
+import numpy as np
+
 
 class TranspositionTable:
-    def __init__(self, dct: Dict[int, Dict[str, float]]) -> None:
+    def __init__(self, dct: Dict[np.int64, Dict[str, float]]) -> None:
         """
         Initialize the TranspositionTable object, wrapping a shared_dict.
 
@@ -11,7 +13,7 @@ class TranspositionTable:
 
     def store(
         self,
-        zobrist_hash: int,
+        zobrist_hash: np.int64,
         depth: int,
         score: float,
     ) -> None:
@@ -25,7 +27,7 @@ class TranspositionTable:
         """
         self._table[zobrist_hash] = {"depth": depth, "score": score}
 
-    def probe(self, zobrist_hash: int, depth: int) -> Optional[Dict]:
+    def probe(self, zobrist_hash: np.int64, depth: int) -> Optional[Dict]:
         """
         Retrieve an entry from the transposition table.
 

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -196,6 +196,7 @@ class ZobristHasher:
         :return: An object containing the Zobrist hash value and other board state information.
         :rtype: ZobristStateInfo
         """
+        # colored_piece_types for all pieces that exist on the board
         squares_colored_piece_types = np.array(
             [
                 [square, hash(piece)]
@@ -204,6 +205,7 @@ class ZobristHasher:
             ],
             dtype=np.int8,
         )
+        # Splice into two arrays
         squares = squares_colored_piece_types[:, 0]
         colored_piece_types = squares_colored_piece_types[:, 1]
 
@@ -243,23 +245,23 @@ class ZobristHasher:
         from_color_piece_type = hash(previous_from_square_piece)
 
         # XOR out the previous from square piece
-        _squares = [move.from_square]
-        _colored_piece_types = [from_color_piece_type]
+        squares_list = [move.from_square]
+        colored_piece_types_list = [from_color_piece_type]
 
         # XOR in the to square piece, piece type depending on if promoted or not
-        _squares.append(move.to_square)
+        squares_list.append(move.to_square)
         if move.promotion:
-            _colored_piece_types.append(hash(board.piece_at(move.to_square)))
+            colored_piece_types_list.append(hash(board.piece_at(move.to_square)))
         else:
-            _colored_piece_types.append(from_color_piece_type)
+            colored_piece_types_list.append(from_color_piece_type)
 
         # XOR out the captured piece if exists
         if captured_piece:
-            _squares.append(move.to_square)
-            _colored_piece_types.append(hash(captured_piece))
+            squares_list.append(move.to_square)
+            colored_piece_types_list.append(hash(captured_piece))
 
-        squares = np.array(_squares, dtype=np.int8)
-        colored_piece_types = np.array(_colored_piece_types, dtype=np.int8)
+        squares = np.array(squares_list, dtype=np.int8)
+        colored_piece_types = np.array(colored_piece_types_list, dtype=np.int8)
 
         ep_file = ZobristHasher._parse_ep_file(board)
         castling_rights = ZobristHasher._parse_castling_rights(board)

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -181,6 +181,7 @@ class ZobristHasher:
         )
         squares = squares_colored_piece_types[:, 0]
         colored_piece_types = squares_colored_piece_types[:, 1]
+
         ep_file = ZobristHasher._parse_ep_file(board)
         castling_rights = ZobristHasher._parse_castling_rights(board)
 
@@ -196,14 +197,17 @@ class ZobristHasher:
         prev_state: ZobristStateInfo,
         captured_piece: Optional[chess.Piece],
     ) -> ZobristStateInfo:
-        squares = [move.from_square, move.to_square]
-        from_color_piece_type = hash(board.piece_at(move.to_square))
-        colored_piece_types = [from_color_piece_type]
+        # This isn't right, it should use the piece type before the move
+        to_color_piece_type = hash(board.piece_at(move.to_square))
+        squares = [move.from_square]
+        colored_piece_types = [to_color_piece_type]
 
         if move.promotion:
+            squares.append(move.to_square)
             colored_piece_types.append(hash(board.piece_at(move.to_square)))
         else:
-            colored_piece_types.append(from_color_piece_type)
+            squares.append(move.to_square)
+            colored_piece_types.append(to_color_piece_type)
 
         if captured_piece:
             squares.append(move.to_square)

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -83,7 +83,7 @@ def _full_zobrist_hash(
     en_passant_file: np.int64,
     castling_rights: np.ndarray,
 ) -> np.int64:
-    # Here we send all the colored_piece types for all piecse which exist on all the board
+    # Here we send all the colored_piece types for all pieces which exist on all the board
     board_hash = _aggregate_piece_hash(np.int64(0), squares, colored_piece_types)
     board_hash = _conditional_turn_hash(board_hash, board_turn)
     board_hash = _en_passant_hash(board_hash, en_passant_file)

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -64,7 +64,7 @@ def _castling_hash(board_hash: np.int64, castling_rights: np.ndarray) -> np.int6
     num_castle_rights = len(castling_rights)
     assert (
         num_castle_rights == 4
-    ), "There should only be 4 castling rights to check, 2 for black, 2 for white."
+    ), f"There should only be 4 castling rights to check, 2 for black, 2 for white, but got {num_castle_rights}."
 
     # This transforms the castling rights from an array of 4 bools
     # into an int from [0, 15].

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -1,36 +1,140 @@
+from dataclasses import dataclass
+from typing import Optional
+
 import chess
 import numpy as np
 from numba import njit
 
 from .board.board import Board
 
+# TODO: we may revisit this in future as people claim this can affect collision chances
+# We set these globally as we want these to be shared across all Zobrist hashers
+np.random.seed(10101010)
+_piece_keys = np.random.randint(0, 2**64, size=(64, 12), dtype=np.uint64)
+_turn_key = np.random.randint(0, 2**64, dtype=np.uint64)
+_en_passant_keys = np.random.randint(0, 2**64, size=8, dtype=np.uint64)
+_castling_keys = np.random.randint(0, 2**64, size=16, dtype=np.uint64)
 
-class BoardInfo:
 
+@njit(cache=True, nogil=True)
+def _aggregate_piece_hash(
+    board_hash: np.uint64, colored_piece_types: np.ndarray
+) -> np.uint64:
+    new_board_hash = board_hash
+    for square, color_piece_type in colored_piece_types:
+        new_board_hash ^= _piece_keys[square, color_piece_type]  # type: ignore
+    return new_board_hash
+
+
+@njit(cache=True, nogil=True)
+def _turn_hash(board_hash: np.uint64) -> np.uint64:
+    return board_hash ^ _turn_key
+
+
+@njit(cache=True, nogil=True)
+def _conditional_turn_hash(board_hash: np.uint64, board_turn: bool) -> np.uint64:
+    return board_hash ^ _turn_key if board_turn else board_hash
+
+
+@njit(cache=True, nogil=True)
+def _en_passant_hash(board_hash: np.uint64, en_passant_file: np.uint8) -> np.uint64:
+    return (  # type: ignore
+        board_hash ^ _en_passant_keys[en_passant_file]
+        if en_passant_file != np.uint8(-1)
+        else board_hash
+    )
+
+
+@njit(cache=True, nogil=True)
+def _castling_hash(board_hash: np.uint64, castling_rights: np.ndarray) -> np.uint64:
+    # This transforms the castling rights from an array of 4 bools
+    # into an int from [0, 15].
+    assert (
+        len(castling_rights) == 4
+    ), "There should only be 4 castling rights to check, 2 for black, 2 for white."
+
+    castling_keys_idx = 0
+    for idx in range(len(castling_rights)):
+        if castling_rights[idx]:
+            castling_keys_idx += 1 << idx
+    return board_hash ^ _castling_keys[castling_keys_idx]  # type: ignore
+
+
+@njit(cache=True, nogil=True)
+def full_zobrist_hash(
+    colored_piece_types: np.ndarray,
+    board_turn: bool,
+    en_passant_file: np.uint64,
+    castling_rights: np.ndarray,
+) -> np.uint64:
+    # Here we send all the colored_piece types
+    board_hash = _aggregate_piece_hash(np.uint64(0), colored_piece_types)
+    board_hash = _conditional_turn_hash(board_hash, board_turn)
+    board_hash = _en_passant_hash(board_hash, en_passant_file)
+    board_hash = _castling_hash(board_hash, castling_rights)
+    return board_hash
+
+
+@njit(cache=True, nogil=True)
+def incremental_zobrist_hash(
+    initial_hash: np.uint64,
+    colored_piece_types: np.ndarray,
+    prev_en_passant_file: np.uint8,
+    curr_en_passant_file: np.uint8,
+    prev_castling_rights: np.uint8,
+    curr_castling_rights: np.uint8,
+) -> np.uint64:
+    # Here we send in only the colored_piece_types for the new move
+    # If capturing, the original piece is sent in to be XOR'd out
+    # Promotions are included already as part of the colored_piece_type for the new move
+    board_hash = _aggregate_piece_hash(initial_hash, colored_piece_types)
+
+    # We hash on every turn, to XOR out the previous turn hash.
+    board_hash = _turn_hash(board_hash)
+
+    # We do pairwise hashes for en en passant and castling, based on the previous and current rights.
+    # The first one XOR's away the previous rights and the second adds the current rights.
+    # If previous_rights == current_rights then we obtain the same result as before.
+    # This is likely faster than checking if both arrays are the same (to be tested).
+    board_hash = _en_passant_hash(board_hash, prev_en_passant_file)
+    board_hash = _en_passant_hash(board_hash, curr_en_passant_file)
+
+    board_hash = _castling_hash(board_hash, prev_castling_rights)
+    board_hash = _castling_hash(board_hash, curr_castling_rights)
+
+    return board_hash
+
+
+@dataclass
+class ZobristStateInfo:
     """
-    Represents information about a chess board used for hashing.
-
-    Attributes:
-    - colored_piece_types (numpy.ndarray): Array of colored piece types on each square.
-    - board_turn (bool): True if it's black's turn, False otherwise.
-    - en_passant_file (int): File index of the en passant square or -1 if not an en passant square.
-    - castling_rights (numpy.ndarray): Array indicating castling rights.
+    Store the information from the current state of the board.
+    It contains board level information be used in computation of the Zobrist incremental hash.
     """
 
-    def __init__(self, board: Board) -> None:
-        self.colored_piece_types = np.array(
-            [
-                # This won't have hash collisions as all the piece indices are > 0
-                hash(piece) if (piece := board.piece_at(square)) else -1
-                for square in chess.SQUARES
-            ],
-            dtype=np.int8,
+    zobrist_hash: np.uint64
+    ep_file: np.uint64
+    castling_rights: np.ndarray
+
+
+class ZobristHasher:
+    def _init_(self) -> None:
+        """
+        Initialize the Zobrist Hasher object, used to hash board positions.
+        This allows caching via the transposition table, so we don't have to evaluate positions twice.
+        """
+
+    @staticmethod
+    def _parse_ep_file(board: Board) -> np.uint8:
+        return (
+            np.uint8(chess.square_file(board.ep_square))
+            if board.ep_square
+            else np.uint8(-1)
         )
-        self.board_turn: bool = board.turn
-        self.en_passant_file: int = (
-            chess.square_file(board.ep_square) if board.ep_square else -1
-        )
-        self.castling_rights = np.array(  # type: ignore
+
+    @staticmethod
+    def _parse_castling_rights(board: Board) -> np.ndarray:
+        return np.array(  # type: ignore
             [
                 board.has_kingside_castling_rights(chess.WHITE),
                 board.has_queenside_castling_rights(chess.WHITE),
@@ -40,65 +144,9 @@ class BoardInfo:
             dtype=bool,
         )
 
-
-@njit
-def _hash(
-    colored_piece_types: np.ndarray,
-    piece_hashes: np.ndarray,
-    board_turn: bool,
-    turn_hash: np.int64,
-    en_passant_file: np.int64,
-    en_passant_hashes: np.ndarray,
-    castling_rights: np.ndarray,
-    castling_hashes: np.ndarray,
-) -> int:
-    board_hash = np.int64(0)
-    for square, color_piece_type in enumerate(colored_piece_types):
-        # Get rid of the squares which don't have pieces
-        if color_piece_type != -1:
-            board_hash ^= piece_hashes[square, color_piece_type]  # type: ignore
-
-    if board_turn == chess.BLACK:
-        board_hash ^= turn_hash
-
-    if en_passant_file >= 0:
-        board_hash ^= en_passant_hashes[en_passant_file]  # type: ignore
-
-    for i, castling_right in enumerate(castling_rights):
-        if castling_right:
-            board_hash ^= castling_hashes[i]  # type: ignore
-
-    return int(board_hash)
-
-
-class ZobristHasher:
-    def __init__(self) -> None:
+    def full_zobrist_hash(self, board: Board) -> ZobristStateInfo:
         """
-        Initialize the Zobrist Hasher object, used to hash board positions.
-        This allows caching via the transposition table, so we don't have to evaluate positions twice.
-
-        Attributes:
-        - _piece_hashes (numpy.ndarray): Zobrist hash values for each piece on each square.
-        - _turn_hash (np.uint64): Zobrist hash value for the side to move.
-        - _en_passant_hashes (numpy.ndarray): Zobrist hash values for en passant squares.
-        - _castling_hashes (numpy.ndarray): Zobrist hash values for castling rights.
-
-        Methods:
-        - __init__(): Initialize the Zobrist Hasher object.
-        - hash(board) -> int: Hashes the given chess board using Zobrist hashing.
-        """
-        # Sporkfish's lucky number
-        np.random.seed(10101010)
-
-        self._piece_hashes = np.random.randint(0, 2**64, size=(64, 12), dtype=np.uint64)
-        self._turn_hash = np.random.randint(0, 2**64, dtype=np.uint64)
-
-        self._en_passant_hashes = np.random.randint(0, 2**64, size=8, dtype=np.uint64)
-        self._castling_hashes = np.random.randint(0, 2**64, size=4, dtype=np.uint64)
-
-    def hash(self, board: Board) -> int:
-        """
-        Hashes the given chess board using Zobrist hashing.
+        Hashes the given a static chess board using Zobrist hashing.
 
         Parameters:
         - board (Board): The chess board.
@@ -107,15 +155,50 @@ class ZobristHasher:
         - int: The computed Zobrist hash value for the board.
         """
 
-        board_info = BoardInfo(board)
-
-        return _hash(  # type: ignore
-            board_info.colored_piece_types,
-            self._piece_hashes,
-            board_info.board_turn,
-            self._turn_hash,
-            board_info.en_passant_file,
-            self._en_passant_hashes,
-            board_info.castling_rights,
-            self._castling_hashes,
+        colored_piece_types = np.array(
+            [
+                # TODO: consider more cache friendly of doing this
+                [square, hash(piece)]
+                for square in chess.SQUARES
+                if (piece := board.piece_at(square))
+            ],
+            dtype=np.uint8,
         )
+        ep_file = ZobristHasher._parse_ep_file(board)
+        castling_rights = ZobristHasher._parse_castling_rights(board)
+
+        zobrist_hash = full_zobrist_hash(  # type: ignore
+            colored_piece_types, board.turn, ep_file, castling_rights
+        )
+        return ZobristStateInfo(zobrist_hash, ep_file, castling_rights)
+
+    def incremental_zobrist_hash(
+        self,
+        board: Board,
+        move: chess.Move,
+        prev_state: ZobristStateInfo,
+        captured_piece: Optional[chess.Piece],
+    ) -> ZobristStateInfo:
+        colored_piece_types = np.array(
+            [
+                [move.from_square, hash(board.piece_at(move.from_square))],
+                [move.to_square, hash(board.piece_at(move.to_square))],
+            ],
+            dtype=np.uint8,
+        )
+        if captured_piece:
+            np.append(
+                colored_piece_types,
+                [[move.to_square, hash(captured_piece)]],
+            )
+        ep_file = ZobristHasher._parse_ep_file(board)
+        castling_rights = ZobristHasher._parse_castling_rights(board)
+        zobrist_hash = incremental_zobrist_hash(
+            prev_state.zobrist_hash,
+            colored_piece_types,
+            prev_state.ep_file,
+            ep_file,
+            prev_state.castling_rights,
+            castling_rights,
+        )
+        return ZobristStateInfo(zobrist_hash, ep_file, castling_rights)

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -156,7 +156,7 @@ class ZobristHasher:
         Parse the en passant file from the given board.
 
         :param board: The chess board.
-        :type board: chess.Board
+        :type board: Board
 
         :return: The file where en passant is possible.
         :rtype: np.int8
@@ -173,7 +173,7 @@ class ZobristHasher:
         Parse the castling rights from the given board.
 
         :param board: The chess board.
-        :type board: chess.Board
+        :type board: Board
 
         :return: An array representing castling rights.
         :rtype: np.ndarray

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -141,14 +141,12 @@ class ZobristStateInfo:
 
 
 class ZobristHasher:
-    def _init_(self) -> None:
-        """
-        Initialize the Zobrist Hasher object, used to hash board positions.
-        This allows caching via the transposition table, so we don't have to evaluate positions twice.
-        Two methods are provided:
-        One hashes the board statically, doing this by retrieving the full board and hence is slow.
-        The other hashes the board after a move is made (i.e. incrementally), and is designed to be faster.
-        """
+    """
+    This allows caching via the transposition table, so we don't have to evaluate positions twice.
+    Two methods are provided:
+    - One hashes the board statically, doing this by retrieving the full board and hence is slow.
+    - The other hashes the board after a move is made (i.e. incrementally), and is designed to be faster.
+    """
 
     @staticmethod
     def _parse_ep_file(board: Board) -> np.int8:

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -88,7 +88,7 @@ def _full_zobrist_hash(
     board_hash = _conditional_turn_hash(board_hash, board_turn)
     board_hash = _en_passant_hash(board_hash, en_passant_file)
     board_hash = _castling_hash(board_hash, castling_rights)
-    return board_hash
+    return board_hash  # type: ignore
 
 
 @njit(cache=True, nogil=True)
@@ -119,7 +119,7 @@ def _incremental_zobrist_hash(
     board_hash = _castling_hash(board_hash, prev_castling_rights)
     board_hash = _castling_hash(board_hash, curr_castling_rights)
 
-    return board_hash
+    return board_hash  # type: ignore
 
 
 @dataclass
@@ -162,7 +162,7 @@ class ZobristHasher:
         :rtype: np.int8
         """
         return (
-            np.int8(chess.square_file(board.ep_square))
+            np.int8(chess.square_file(board.ep_square))  # type: ignore
             if board.ep_square
             else _int8_max_val
         )
@@ -245,23 +245,23 @@ class ZobristHasher:
         from_color_piece_type = hash(previous_from_square_piece)
 
         # XOR out the previous from square piece
-        squares = [move.from_square]
-        colored_piece_types = [from_color_piece_type]
+        _squares = [move.from_square]
+        _colored_piece_types = [from_color_piece_type]
 
         # XOR in the to square piece, piece type depending on if promoted or not
-        squares.append(move.to_square)
+        _squares.append(move.to_square)
         if move.promotion:
-            colored_piece_types.append(hash(board.piece_at(move.to_square)))
+            _colored_piece_types.append(hash(board.piece_at(move.to_square)))
         else:
-            colored_piece_types.append(from_color_piece_type)
+            _colored_piece_types.append(from_color_piece_type)
 
         # XOR out the captured piece if exists
         if captured_piece:
-            squares.append(move.to_square)
-            colored_piece_types.append(hash(captured_piece))
+            _squares.append(move.to_square)
+            _colored_piece_types.append(hash(captured_piece))
 
-        squares = np.array(squares, dtype=np.int8)
-        colored_piece_types = np.array(colored_piece_types, dtype=np.int8)
+        squares = np.array(_squares, dtype=np.int8)
+        colored_piece_types = np.array(_colored_piece_types, dtype=np.int8)
 
         ep_file = ZobristHasher._parse_ep_file(board)
         castling_rights = ZobristHasher._parse_castling_rights(board)

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -83,7 +83,7 @@ def _full_zobrist_hash(
     en_passant_file: np.int64,
     castling_rights: np.ndarray,
 ) -> np.int64:
-    # Here we send all the colored_piece types
+    # Here we send all the colored_piece types for all piecse which exist on all the board
     board_hash = _aggregate_piece_hash(np.int64(0), squares, colored_piece_types)
     board_hash = _conditional_turn_hash(board_hash, board_turn)
     board_hash = _en_passant_hash(board_hash, en_passant_file)
@@ -101,7 +101,7 @@ def _incremental_zobrist_hash(
     prev_castling_rights: np.ndarray,
     curr_castling_rights: np.ndarray,
 ) -> np.int64:
-    # Here we send in only the colored_piece_types for the new move
+    # Here we send in only the colored_piece_types for the input move
     # If capturing, the original piece is sent in to be XOR'd out
     # Promotions are included already as part of the colored_piece_type for the new move
     board_hash = _aggregate_piece_hash(initial_hash, squares, colored_piece_types)
@@ -109,7 +109,7 @@ def _incremental_zobrist_hash(
     # We hash on every turn, to XOR out the previous turn hash.
     board_hash = _turn_hash(board_hash)
 
-    # We do pairwise hashes for en en passant and castling, based on the previous and current rights.
+    # We do pairwise hashes for en passant and castling, based on the previous and current rights.
     # The first one XOR's away the previous rights and the second adds the current rights.
     # If previous_rights == current_rights then we obtain the same result as before.
     # This is likely faster than checking if both arrays are the same (to be tested).

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -377,7 +377,7 @@ class TestNegamax:
         s = _init_searcher
 
         alpha, beta = param[0], param[1]
-        result = s._negamax(board, 0, alpha, beta)
+        result = s._negamax(board, 0, alpha, beta, None)
         assert result == s._quiescence(board, 4, alpha, beta)
 
     def test_negamax_depth_1(
@@ -390,7 +390,7 @@ class TestNegamax:
         s = _init_searcher
 
         alpha, beta = param[0], param[1]
-        result = s._negamax(board, 1, alpha, beta)
+        result = s._negamax(board, 1, alpha, beta, None)
 
         legal_moves = board.legal_moves
         legal_moves = s._ordered_moves(board, legal_moves)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -130,13 +130,13 @@ class TestPerformance:
 
         sys.stdout = sys.__stdout__
 
-    # @pytest.mark.slow
-    # def test_perf_base(self, request_fixture, fen_string: str, max_depth: int) -> None:
-    #     self._run_perf_analytics(
-    #         request_fixture.node.name,
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #     )
+    @pytest.mark.slow
+    def test_perf_base(self, request_fixture, fen_string: str, max_depth: int) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+        )
 
     @pytest.mark.slow
     def test_perf_transposition_table(
@@ -149,63 +149,63 @@ class TestPerformance:
             enable_transposition_table=True,
         )
 
-    # @pytest.mark.slow
-    # def test_perf_null_move_pruning(
-    #     self, request_fixture, fen_string: str, max_depth: int
-    # ) -> None:
-    #     self._run_perf_analytics(
-    #         request_fixture.node.name,
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_null_move_pruning=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_null_move_pruning(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_aspiration_windows(
-    #     self, request_fixture, fen_string: str, max_depth: int
-    # ) -> None:
-    #     self._run_perf_analytics(
-    #         request_fixture.node.name,
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_aspiration_windows=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_aspiration_windows(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_aspiration_windows=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_futility_pruning(
-    #     self, request_fixture, fen_string: str, max_depth: int
-    # ) -> None:
-    #     self._run_perf_analytics(
-    #         request_fixture.node.name,
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_futility_pruning=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_futility_pruning(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_futility_pruning=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_delta_pruning(
-    #     self, request_fixture, fen_string: str, max_depth: int
-    # ) -> None:
-    #     self._run_perf_analytics(
-    #         request_fixture.node.name,
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_delta_pruning=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_delta_pruning(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_delta_pruning=True,
+        )
 
-    # @pytest.mark.slow
-    # def test_perf_combined(
-    #     self, request_fixture, fen_string: str, max_depth: int
-    # ) -> None:
-    #     """Performance test with combined general performance config on"""
-    #     self._run_perf_analytics(
-    #         request_fixture.node.name,
-    #         fen=fen_string,
-    #         max_depth=max_depth,
-    #         enable_null_move_pruning=True,
-    #         enable_delta_pruning=True,
-    #         enable_aspiration_windows=True,
-    #     )
+    @pytest.mark.slow
+    def test_perf_combined(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        """Performance test with combined general performance config on"""
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+            enable_delta_pruning=True,
+            enable_aspiration_windows=True,
+        )
 
 
 @pytest.mark.parametrize(
@@ -377,7 +377,7 @@ class TestNegamax:
         s = _init_searcher
 
         alpha, beta = param[0], param[1]
-        result = s._negamax(board, 0, alpha, beta, None)
+        result = s._negamax(board, 0, alpha, beta)
         assert result == s._quiescence(board, 4, alpha, beta)
 
     def test_negamax_depth_1(
@@ -390,7 +390,7 @@ class TestNegamax:
         s = _init_searcher
 
         alpha, beta = param[0], param[1]
-        result = s._negamax(board, 1, alpha, beta, None)
+        result = s._negamax(board, 1, alpha, beta)
 
         legal_moves = board.legal_moves
         legal_moves = s._ordered_moves(board, legal_moves)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -390,7 +390,7 @@ class TestNegamax:
         s = _init_searcher
 
         alpha, beta = param[0], param[1]
-        result = s._negamax(board, 1, alpha, beta)
+        result = s._negamax(board, 1, alpha, beta, None)
 
         legal_moves = board.legal_moves
         legal_moves = s._ordered_moves(board, legal_moves)

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -130,13 +130,13 @@ class TestPerformance:
 
         sys.stdout = sys.__stdout__
 
-    @pytest.mark.slow
-    def test_perf_base(self, request_fixture, fen_string: str, max_depth: int) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-        )
+    # @pytest.mark.slow
+    # def test_perf_base(self, request_fixture, fen_string: str, max_depth: int) -> None:
+    #     self._run_perf_analytics(
+    #         request_fixture.node.name,
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #     )
 
     @pytest.mark.slow
     def test_perf_transposition_table(
@@ -149,63 +149,63 @@ class TestPerformance:
             enable_transposition_table=True,
         )
 
-    @pytest.mark.slow
-    def test_perf_null_move_pruning(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_null_move_pruning(
+    #     self, request_fixture, fen_string: str, max_depth: int
+    # ) -> None:
+    #     self._run_perf_analytics(
+    #         request_fixture.node.name,
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_null_move_pruning=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_aspiration_windows(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_aspiration_windows=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_aspiration_windows(
+    #     self, request_fixture, fen_string: str, max_depth: int
+    # ) -> None:
+    #     self._run_perf_analytics(
+    #         request_fixture.node.name,
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_aspiration_windows=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_futility_pruning(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_futility_pruning=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_futility_pruning(
+    #     self, request_fixture, fen_string: str, max_depth: int
+    # ) -> None:
+    #     self._run_perf_analytics(
+    #         request_fixture.node.name,
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_futility_pruning=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_delta_pruning(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_delta_pruning=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_delta_pruning(
+    #     self, request_fixture, fen_string: str, max_depth: int
+    # ) -> None:
+    #     self._run_perf_analytics(
+    #         request_fixture.node.name,
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_delta_pruning=True,
+    #     )
 
-    @pytest.mark.slow
-    def test_perf_combined(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        """Performance test with combined general performance config on"""
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-            enable_delta_pruning=True,
-            enable_aspiration_windows=True,
-        )
+    # @pytest.mark.slow
+    # def test_perf_combined(
+    #     self, request_fixture, fen_string: str, max_depth: int
+    # ) -> None:
+    #     """Performance test with combined general performance config on"""
+    #     self._run_perf_analytics(
+    #         request_fixture.node.name,
+    #         fen=fen_string,
+    #         max_depth=max_depth,
+    #         enable_null_move_pruning=True,
+    #         enable_delta_pruning=True,
+    #         enable_aspiration_windows=True,
+    #     )
 
 
 @pytest.mark.parametrize(
@@ -377,7 +377,7 @@ class TestNegamax:
         s = _init_searcher
 
         alpha, beta = param[0], param[1]
-        result = s._negamax(board, 0, alpha, beta)
+        result = s._negamax(board, 0, alpha, beta, None)
         assert result == s._quiescence(board, 4, alpha, beta)
 
     def test_negamax_depth_1(

--- a/tests/test_zobrist_hash.py
+++ b/tests/test_zobrist_hash.py
@@ -1,4 +1,4 @@
-from sporkfish.board.board_factory import Board, BoardFactory, BoardPyChess
+from sporkfish.board.board_factory import BoardFactory, BoardPyChess
 from sporkfish.zobrist_hasher import ZobristHasher
 
 
@@ -16,41 +16,58 @@ class TestZobristHashFull:
 
     def test_full_hash_no_collision(self):
         zh = ZobristHasher()
+        board = BoardFactory.create(BoardPyChess)
+        s = set()
 
-        def check(board: Board):
-            s = set()
-            for move in board.legal_moves:
-                board.push(move)
+        for move in board.legal_moves:
+            board.push(move)
 
-                hash = zh.full_zobrist_hash(board).zobrist_hash
-                assert hash not in s
-                s.add(hash)
+            hash = zh.full_zobrist_hash(board).zobrist_hash
+            assert hash not in s
+            s.add(hash)
 
-                board.pop()
-
-        check(BoardFactory.create(BoardPyChess))
+            board.pop()
 
 
 class TestZobristHashIncremental:
     def test_inc_hash_consistency_basic(self):
         zh = ZobristHasher()
+        board = BoardFactory.create(BoardPyChess)
 
-        def check(board: Board):
-            initial_zobrist_state = zh.full_zobrist_hash(board)
-            for move in board.legal_moves:
-                captured_piece = (
-                    board.piece_at(move.to_square) if board.is_capture(move) else None
-                )
-                board.push(move)
+        initial_zobrist_state = zh.full_zobrist_hash(board)
+        for move in board.legal_moves:
+            captured_piece = (
+                board.piece_at(move.to_square) if board.is_capture(move) else None
+            )
+            board.push(move)
 
-                hash = zh.full_zobrist_hash(board).zobrist_hash
-                inc_hash = zh.incremental_zobrist_hash(
-                    board, move, initial_zobrist_state, captured_piece
-                ).zobrist_hash
-                assert (
-                    hash == inc_hash
-                ), f"Incremental hash consistency failed for move {move}"
+            hash = zh.full_zobrist_hash(board).zobrist_hash
+            inc_hash = zh.incremental_zobrist_hash(
+                board, move, initial_zobrist_state, captured_piece
+            ).zobrist_hash
 
-                board.pop()
+            assert (
+                hash == inc_hash
+            ), f"Incremental hash consistency failed for move {move}"
 
-        check(BoardFactory.create(BoardPyChess))
+            board.pop()
+
+    def test_inc_hash_consistency_capture(self):
+        zh = ZobristHasher()
+        board = BoardFactory.create(BoardPyChess)
+        initial_zobrist_state = zh.full_zobrist_hash(board)
+
+        board.set_fen("rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 1")
+        capturing_moves = [move for move in board.legal_moves if board.is_capture(move)]
+        assert len(capturing_moves) == 1, "Should only be one capturing move."
+        move = capturing_moves[0]
+        captured_piece = board.piece_at(move.to_square)
+
+        board.push(move)
+
+        hash = zh.full_zobrist_hash(board).zobrist_hash
+        inc_hash = zh.incremental_zobrist_hash(
+            board, move, initial_zobrist_state, captured_piece
+        ).zobrist_hash
+
+        assert hash == inc_hash, f"Incremental hash consistency failed for move {move}"

--- a/tests/test_zobrist_hash.py
+++ b/tests/test_zobrist_hash.py
@@ -5,10 +5,10 @@ from sporkfish.zobrist_hasher import ZobristHasher
 def test_seeded_and_equivalent():
     zh1 = ZobristHasher()
     board = BoardFactory.create(BoardPyChess)
-    hash1 = zh1.hash(board)
+    hash1 = zh1.full_zobrist_hash(board).zobrist_hash
 
     zh2 = ZobristHasher()
-    hash2 = zh2.hash(board)
+    hash2 = zh2.full_zobrist_hash(board).zobrist_hash
     # Make sure internal hashes are equivalent (i.e. we seeded the random numbers) by checking the final hash.
     # Also check the final hashes are the same for the same board
     assert hash1 == hash2
@@ -22,7 +22,7 @@ def test_no_hash_collision():
         for move in board.legal_moves:
             board.push(move)
 
-            hash = zh.hash(board)
+            hash = zh.full_zobrist_hash(board).zobrist_hash
             assert hash not in s
             s.add(hash)
 

--- a/tests/test_zobrist_hash.py
+++ b/tests/test_zobrist_hash.py
@@ -1,3 +1,6 @@
+import chess
+import pytest
+
 from sporkfish.board.board_factory import BoardFactory, BoardPyChess
 from sporkfish.zobrist_hasher import ZobristHasher
 
@@ -30,20 +33,45 @@ class TestZobristHashFull:
 
 
 class TestZobristHashIncremental:
+    """
+    Consistency test of the incremental hash against the full hash
+    """
+
+    @pytest.fixture
+    def _setup_board_and_move(self, fen, move_uci):
+        zh = ZobristHasher()
+        board = BoardFactory.create(BoardPyChess)
+        board.set_fen(fen)
+        initial_zobrist_state = zh.full_zobrist_hash(board)
+        move = chess.Move.from_uci(move_uci)
+        previous_move_from_square = board.piece_at(move.from_square)
+        captured_piece = board.piece_at(move.to_square)
+        board.push(move)
+        return (
+            zh,
+            board,
+            initial_zobrist_state,
+            move,
+            previous_move_from_square,
+            captured_piece,
+        )
+
     def test_inc_hash_consistency_basic(self):
         zh = ZobristHasher()
         board = BoardFactory.create(BoardPyChess)
 
         initial_zobrist_state = zh.full_zobrist_hash(board)
         for move in board.legal_moves:
-            captured_piece = (
-                board.piece_at(move.to_square) if board.is_capture(move) else None
-            )
+            previous_move_from_square = board.piece_at(move.from_square)
             board.push(move)
 
             hash = zh.full_zobrist_hash(board).zobrist_hash
             inc_hash = zh.incremental_zobrist_hash(
-                board, move, initial_zobrist_state, captured_piece
+                board,
+                move,
+                initial_zobrist_state,
+                previous_move_from_square,
+                None,  # No capturing moves from starting pos
             ).zobrist_hash
 
             assert (
@@ -52,22 +80,61 @@ class TestZobristHashIncremental:
 
             board.pop()
 
-    def test_inc_hash_consistency_capture(self):
-        zh = ZobristHasher()
-        board = BoardFactory.create(BoardPyChess)
-        initial_zobrist_state = zh.full_zobrist_hash(board)
-
-        board.set_fen("rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 1")
-        capturing_moves = [move for move in board.legal_moves if board.is_capture(move)]
-        assert len(capturing_moves) == 1, "Should only be one capturing move."
-        move = capturing_moves[0]
-        captured_piece = board.piece_at(move.to_square)
-
-        board.push(move)
-
+    @pytest.mark.parametrize(
+        "test_name, fen, move_uci",
+        [
+            (
+                "capture",
+                "rnbqkbnr/pppp1ppp/8/4p3/3P4/8/PPP1PPPP/RNBQKBNR w KQkq - 0 1",
+                "d4e5",
+            ),
+            (
+                "promotion",
+                "rnbq3r/ppppkP1p/5n1b/8/6p1/2N5/PPP1N1PP/R1BQKB1R w KQ - 0 1",
+                "f7f8q",
+            ),
+            (
+                "capturing_promotion",
+                "rnbq2r1/ppppkP1p/5n1b/8/6p1/2N5/PPPBN1PP/R2QKB1R w KQ - 0 1",
+                "f7g8q",
+            ),
+            (
+                "en_passant",
+                "rnbqkbnr/ppppp2p/6p1/4Pp2/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 1",
+                "e5f6",
+            ),
+            (
+                "black_no_kingside_castling",
+                "rnbqk1nr/ppppb1Qp/6p1/5p2/4P3/8/PPPP1PPP/RNB1KBNR w KQq - 0 1",
+                "h2h4",
+            ),
+            (
+                "black_no_castling",
+                "rnbq1bnr/pppppk1p/6p1/5p2/5P2/6P1/PPPPP2P/RNBQKBNR w KQ - 0 1",
+                "h2h4",
+            ),
+            (
+                "all_no_castling",
+                "rnbq1bnr/pppppk1p/6p1/5p2/5P2/6P1/PPPPPK1P/RNBQ1BNR w - - 0 1",
+                "h2h4",
+            ),
+        ],
+    )
+    def test_inc_hash_consistency(self, _setup_board_and_move, test_name):
+        (
+            zh,
+            board,
+            initial_zobrist_state,
+            move,
+            previous_move_from_square,
+            captured_piece,
+        ) = _setup_board_and_move
         hash = zh.full_zobrist_hash(board).zobrist_hash
         inc_hash = zh.incremental_zobrist_hash(
-            board, move, initial_zobrist_state, captured_piece
+            board,
+            move,
+            initial_zobrist_state,
+            previous_move_from_square,
+            captured_piece,
         ).zobrist_hash
-
-        assert hash == inc_hash, f"Incremental hash consistency failed for move {move}"
+        assert hash == inc_hash, f"{test_name} failed for move {move}"

--- a/tests/test_zobrist_hash.py
+++ b/tests/test_zobrist_hash.py
@@ -2,30 +2,55 @@ from sporkfish.board.board_factory import Board, BoardFactory, BoardPyChess
 from sporkfish.zobrist_hasher import ZobristHasher
 
 
-def test_seeded_and_equivalent():
-    zh1 = ZobristHasher()
-    board = BoardFactory.create(BoardPyChess)
-    hash1 = zh1.full_zobrist_hash(board).zobrist_hash
+class TestZobristHashFull:
+    def test_full_hash_seeded_and_equivalent(self):
+        zh1 = ZobristHasher()
+        board = BoardFactory.create(BoardPyChess)
+        hash1 = zh1.full_zobrist_hash(board).zobrist_hash
 
-    zh2 = ZobristHasher()
-    hash2 = zh2.full_zobrist_hash(board).zobrist_hash
-    # Make sure internal hashes are equivalent (i.e. we seeded the random numbers) by checking the final hash.
-    # Also check the final hashes are the same for the same board
-    assert hash1 == hash2
+        zh2 = ZobristHasher()
+        hash2 = zh2.full_zobrist_hash(board).zobrist_hash
+        # Make sure internal hashes are equivalent (i.e. we seeded the random numbers) by checking the final hash.
+        # Also check the final hashes are the same for the same board
+        assert hash1 == hash2
+
+    def test_full_hash_no_collision(self):
+        zh = ZobristHasher()
+
+        def check(board: Board):
+            s = set()
+            for move in board.legal_moves:
+                board.push(move)
+
+                hash = zh.full_zobrist_hash(board).zobrist_hash
+                assert hash not in s
+                s.add(hash)
+
+                board.pop()
+
+        check(BoardFactory.create(BoardPyChess))
 
 
-def test_no_hash_collision():
-    zh = ZobristHasher()
+class TestZobristHashIncremental:
+    def test_inc_hash_consistency_basic(self):
+        zh = ZobristHasher()
 
-    def check(board: Board):
-        s = set()
-        for move in board.legal_moves:
-            board.push(move)
+        def check(board: Board):
+            initial_zobrist_state = zh.full_zobrist_hash(board)
+            for move in board.legal_moves:
+                captured_piece = (
+                    board.piece_at(move.to_square) if board.is_capture(move) else None
+                )
+                board.push(move)
 
-            hash = zh.full_zobrist_hash(board).zobrist_hash
-            assert hash not in s
-            s.add(hash)
+                hash = zh.full_zobrist_hash(board).zobrist_hash
+                inc_hash = zh.incremental_zobrist_hash(
+                    board, move, initial_zobrist_state, captured_piece
+                ).zobrist_hash
+                assert (
+                    hash == inc_hash
+                ), f"Incremental hash consistency failed for move {move}"
 
-            board.pop()
+                board.pop()
 
-    check(BoardFactory.create(BoardPyChess))
+        check(BoardFactory.create(BoardPyChess))


### PR DESCRIPTION
Implements incremental Zobrist hash as opposed to computing the hash via full information.

This leads the performance to be fairly equal to base case:

FEN: 8/8/8/8/5R2/2pk4/5K2/8 b - - 0 1
Base, 20302099 function calls (20229039 primitive calls) in 6.205 seconds
Transposition table, 11647835 function calls (11604146 primitive calls) in 4.043 seconds

FEN: r1b2rk1/ppqn1pbp/6p1/3pp3/7B/2PB1N2/PP3PPP/R2QR1K1 w - - 0 16
Base, 48916378 function calls (48808919 primitive calls) in 16.903 seconds
TT, 50581630 function calls (50466170 primitive calls) in 17.850 seconds (I am not sure why more function calls here either)

I am not quite happy with it yet, but would like this to go in as this is a vast improvement over full hash computation. Will explore avenues of improvement of TT and optimizing the hash calculation in next PR.