### PR TITLE
Enriching current statistics framework

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import logging.config
 import multiprocessing
 
 from config import load_config
-from sporkfish.runner import Runner, RunConfig
+from sporkfish.runner import RunConfig, Runner
 
 if __name__ == "__main__":
     config = load_config()

--- a/sporkfish/searcher/minimax.py
+++ b/sporkfish/searcher/minimax.py
@@ -17,7 +17,7 @@ from sporkfish.searcher.move_ordering.move_orderer import MoveOrderer
 from sporkfish.searcher.move_ordering.mvv_lva_heuristic import MvvLvaHeuristic
 from sporkfish.searcher.searcher import Searcher
 from sporkfish.searcher.searcher_config import SearcherConfig
-from sporkfish.statistics import NodeTypes, Statistics
+from sporkfish.statistics import NodeTypes
 from sporkfish.transposition_table import TranspositionTable
 from sporkfish.zobrist_hasher import ZobristHasher, ZobristStateInfo
 
@@ -219,6 +219,7 @@ class MiniMaxVariants(Searcher, ABC):
             return stand_pat
 
         if stand_pat >= beta:
+            self._statistics.increment_pruning()
             return beta
 
         if alpha < stand_pat:
@@ -230,9 +231,11 @@ class MiniMaxVariants(Searcher, ABC):
         )
 
         for move in legal_moves:
+            # delta pruning
             if self._searcher_config.enable_delta_pruning and self._delta_pruning(
                 board, move, stand_pat, alpha
             ):
+                self._statistics.increment_pruning()
                 continue
 
             # Get the piece from the originating square and the captured piece

--- a/sporkfish/searcher/negamax.py
+++ b/sporkfish/searcher/negamax.py
@@ -7,7 +7,7 @@ from sporkfish.evaluator.evaluator import Evaluator
 from sporkfish.searcher.minimax import MiniMaxVariants
 from sporkfish.searcher.move_ordering.move_orderer import MoveOrderer
 from sporkfish.searcher.searcher_config import SearcherConfig
-from sporkfish.statistics import NodeTypes, Statistics
+from sporkfish.statistics import NodeTypes
 from sporkfish.zobrist_hasher import ZobristStateInfo
 
 
@@ -53,6 +53,7 @@ class NegamaxSp(MiniMaxVariants):
                 zobrist_state.zobrist_hash, depth
             )
         ):
+            self._statistics.increment_nodes_from_tt()
             return tt_entry["score"]  # type: ignore
 
         self._statistics.increment_node_visited(NodeTypes.NEGAMAX)
@@ -234,6 +235,7 @@ class NegamaxSp(MiniMaxVariants):
             alpha = max(alpha, value)
             if alpha >= beta:
                 self._update_killer_moves(move, depth)
+                self._statistics.increment_pruning()
                 break
 
         if zobrist_state:

--- a/sporkfish/searcher/negamax_lazy_smp.py
+++ b/sporkfish/searcher/negamax_lazy_smp.py
@@ -8,7 +8,6 @@ from sporkfish.board.board import Board
 from sporkfish.evaluator.evaluator import Evaluator
 from sporkfish.searcher.negamax import NegamaxSp
 from sporkfish.searcher.searcher_config import SearcherConfig
-from sporkfish.statistics import NodeTypes, Statistics
 
 
 # This doesn't really work yet. Don't use.

--- a/sporkfish/searcher/negamax_lazy_smp.py
+++ b/sporkfish/searcher/negamax_lazy_smp.py
@@ -8,6 +8,7 @@ from sporkfish.board.board import Board
 from sporkfish.evaluator.evaluator import Evaluator
 from sporkfish.searcher.negamax import NegamaxSp
 from sporkfish.searcher.searcher_config import SearcherConfig
+from sporkfish.statistics import NodeTypes, Statistics
 
 
 # This doesn't really work yet. Don't use.
@@ -46,6 +47,7 @@ class NegaMaxLazySmp(NegamaxSp):
         """
 
         def task() -> Tuple[float, chess.Move]:
+            # TODO: fix increment statistics
             return NegamaxSp._start_search_from_root(self, board, depth, alpha, beta)
 
         # Let processes race down lazily and see who completes first

--- a/sporkfish/searcher/searcher.py
+++ b/sporkfish/searcher/searcher.py
@@ -56,16 +56,15 @@ class Searcher(ABC):
             else float("nan"),
             "pv": move,  # Incorrect but will do for now
         }
-
         total = 0
         for type in NodeTypes:
             count = self._statistics.nodes_visited[type]
-            fields[f"node {type}"] = count
+            fields[f"Node {type}"] = count
             total += count
-        fields["total nodes visited"] = total
-        fields["nps"] = float(total / elapsed) if elapsed > 0 else 0  # not sure
-        fields["pruning"] = self._statistics.pruned
-        fields["nodes in tt"] = self._statistics.nodes_from_tt
+        fields["Total nodes"] = total
+        fields["Nodes per sec"] = float(total / elapsed) if elapsed > 0 else 0 
+        fields["Num of Pruning"] = self._statistics.pruned
+        fields["Nodes from TT"] = self._statistics.nodes_from_tt
 
         info_str = " ".join(f"{k} {v}" for k, v in fields.items())
         logging.info(f"info {info_str}")

--- a/sporkfish/statistics.py
+++ b/sporkfish/statistics.py
@@ -11,7 +11,7 @@ class NodeTypes(Enum):
 class Statistics:
     """A class for tracking statistics related to node visits."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize the Statistics object.
         Upon initialization, sets the counts of visited nodes, pruned nodes,
@@ -65,7 +65,7 @@ class Statistics:
         """
         self._nodes_in_tt += count
 
-    def reset_node_visited(self, default_val=0) -> None:
+    def reset_node_visited(self, default_val: int = 0) -> None:
         """
         Reset the statistics by setting nodes_visited to a default value.
 
@@ -78,7 +78,7 @@ class Statistics:
         for key in self._nodes_visited.keys():
             self._nodes_visited[key] = default_val
 
-    def reset_pruning(self, default_val=0) -> None:
+    def reset_pruning(self, default_val: int = 0) -> None:
         """
         Reset the pruning count to a default value.
 
@@ -90,7 +90,7 @@ class Statistics:
         """
         self._pruned = default_val
 
-    def reset_nodes_from_tt(self, default_val=0) -> None:
+    def reset_nodes_from_tt(self, default_val: int = 0) -> None:
         """
         Reset the nodes in TT count to a default value.
 

--- a/sporkfish/statistics.py
+++ b/sporkfish/statistics.py
@@ -14,18 +14,20 @@ class Statistics:
     def __init__(self):
         """
         Initialize the Statistics object.
-        Upon initialization, sets the counts of visited nodes, pruned nodes, 
+        Upon initialization, sets the counts of visited nodes, pruned nodes,
         and nodes stored in the transposition table to zero.
         """
         self._nodes_visited = {
             NodeTypes.NEGAMAX: 0,
             NodeTypes.NEGAMAX_LAZY_SMP: 0,
-            NodeTypes.QUIESCENSE: 0
+            NodeTypes.QUIESCENSE: 0,
         }
         self._pruned = 0
         self._nodes_in_tt = 0
 
-    def increment_node_visited(self, visited_node_type: NodeTypes, count: int = 1) -> None:
+    def increment_node_visited(
+        self, visited_node_type: NodeTypes, count: int = 1
+    ) -> None:
         """
         Increment the count of visited nodes of a specified type.
 
@@ -38,6 +40,7 @@ class Statistics:
         """
         self._nodes_visited[visited_node_type] += count
 
+    # TODO: enrich to record types of pruning
     def increment_pruning(self, count: int = 1) -> None:
         """
         Increments the pruning count by the specified amount.
@@ -50,7 +53,7 @@ class Statistics:
         """
         self._pruned += count
 
-    def increment_nodes_in_tt(self, count: int = 1) -> None:
+    def increment_nodes_from_tt(self, count: int = 1) -> None:
         """
         Increments the nodes in TT count by the specified amount.
 
@@ -62,7 +65,7 @@ class Statistics:
         """
         self._nodes_in_tt += count
 
-    def reset_node_visited(self, default_val = 0) -> None:
+    def reset_node_visited(self, default_val=0) -> None:
         """
         Reset the statistics by setting nodes_visited to a default value.
 
@@ -75,7 +78,7 @@ class Statistics:
         for key in self._nodes_visited.keys():
             self._nodes_visited[key] = default_val
 
-    def reset_pruning(self, default_val = 0) -> None:
+    def reset_pruning(self, default_val=0) -> None:
         """
         Reset the pruning count to a default value.
 
@@ -87,7 +90,7 @@ class Statistics:
         """
         self._pruned = default_val
 
-    def reset_nodes_in_tt(self, default_val = 0) -> None:
+    def reset_nodes_from_tt(self, default_val=0) -> None:
         """
         Reset the nodes in TT count to a default value.
 
@@ -108,17 +111,15 @@ class Statistics:
         :rtype: int
         """
         return self._pruned
-    
-    @property
-    def nodes_in_tt(self) -> int:
-        """
-        Returns the count of nodes stored in the transposition table.
 
-        :return: The count of nodes stored in the transposition table.
+    @property
+    def nodes_from_tt(self) -> int:
+        """
+        :return: The count of nodes returned from the transposition table.
         :rtype: int
         """
         return self._nodes_in_tt
-    
+
     @property
     def nodes_visited(self) -> Dict[NodeTypes, int]:
         """
@@ -128,4 +129,3 @@ class Statistics:
         :rtype: dict
         """
         return self._nodes_visited
-

--- a/sporkfish/statistics.py
+++ b/sporkfish/statistics.py
@@ -1,26 +1,84 @@
+from enum import Enum
+from typing import Dict
+
+
+class NodeTypes(Enum):
+    NEGAMAX = "NEGAMAX"
+    NEGAMAX_LAZY_SMP = "NEGAMAX_LAZY_SMP"
+    QUIESCENSE = "QUIESCENSE"
+
+
 class Statistics:
     """A class for tracking statistics related to node visits."""
 
-    def __init__(self, nodes_visited: int):
+    def __init__(self):
         """
         Initialize the Statistics object.
 
         Attributes:
         - nodes_visited (Value): The number of nodes visited. Shared across processes.
         """
-        self.nodes_visited = nodes_visited
+        self._nodes_visited = {
+            NodeTypes.NEGAMAX: 0,
+            NodeTypes.NEGAMAX_LAZY_SMP: 0,
+            NodeTypes.QUIESCENSE: 0
+        }
+        self._pruned = 0
+        self._nodes_in_tt = 0
 
-    def increment(self, count: int = 1) -> None:
+    def increment_node_visited(self, visited_node_type: NodeTypes, count: int = 1) -> None:
         """
         Increment the nodes_visited count.
 
         Parameters:
         - count (int): The number of nodes to increment the count by. Default is 1.
         """
-        self.nodes_visited += count
+        self._nodes_visited[visited_node_type] += count
 
-    def reset(self) -> None:
+    def increment_pruning(self, count: int = 1) -> None:
         """
-        Reset the statistics by setting nodes_visited to 0 and updating start_time to the current time.
+        xxx
         """
-        self.nodes_visited = 0
+        self._pruned += count
+
+    def increment_nodes_in_tt(self, count: int = 1) -> None:
+        """
+        xxx
+        """
+        self._nodes_in_tt += count
+
+    def reset_node_visited(self, default_val = 0) -> None:
+        """
+        Reset the statistics by setting nodes_visited to 0 
+        and updating start_time to the current time. ???
+        """
+        for key in self._nodes_visited.keys():
+            self._nodes_visited[key] = default_val
+
+    def reset_pruning(self, default_val = 0) -> None:
+        self._pruned = default_val
+
+    def reset_nodes_in_tt(self, default_val = 0) -> None:
+        self._nodes_in_tt = default_val
+
+    @property
+    def pruned(self) -> int:
+        """
+        xxx
+        """
+        return self._pruned
+    
+    @property
+    def nodes_in_tt(self) -> int:
+        """
+        xxx
+        """
+        return self._nodes_in_tt
+    
+    @property
+    def nodes_visited(self) -> Dict[NodeTypes, int]:
+        """
+        dda
+        """
+        return self._nodes_visited
+

--- a/sporkfish/statistics.py
+++ b/sporkfish/statistics.py
@@ -14,9 +14,8 @@ class Statistics:
     def __init__(self):
         """
         Initialize the Statistics object.
-
-        Attributes:
-        - nodes_visited (Value): The number of nodes visited. Shared across processes.
+        Upon initialization, sets the counts of visited nodes, pruned nodes, 
+        and nodes stored in the transposition table to zero.
         """
         self._nodes_visited = {
             NodeTypes.NEGAMAX: 0,
@@ -28,57 +27,105 @@ class Statistics:
 
     def increment_node_visited(self, visited_node_type: NodeTypes, count: int = 1) -> None:
         """
-        Increment the nodes_visited count.
+        Increment the count of visited nodes of a specified type.
 
-        Parameters:
-        - count (int): The number of nodes to increment the count by. Default is 1.
+        :param visited_node_type: The type of node being visited.
+        :type visited_node_type: NodeTypes
+        :param count: The number of nodes to increment the count by. Default is 1.
+        :type count: int
+        :return: None
+        :rtype: None
         """
         self._nodes_visited[visited_node_type] += count
 
     def increment_pruning(self, count: int = 1) -> None:
         """
-        xxx
+        Increments the pruning count by the specified amount.
+
+        :param count: The amount by which to increment the pruning count (default is 1).
+        :type count: int
+
+        :return: None
+        :rtype: None
         """
         self._pruned += count
 
     def increment_nodes_in_tt(self, count: int = 1) -> None:
         """
-        xxx
+        Increments the nodes in TT count by the specified amount.
+
+        :param count: The amount by which to increment the pruning count (default is 1).
+        :type count: int
+
+        :return: None
+        :rtype: None
         """
         self._nodes_in_tt += count
 
     def reset_node_visited(self, default_val = 0) -> None:
         """
-        Reset the statistics by setting nodes_visited to 0 
-        and updating start_time to the current time. ???
+        Reset the statistics by setting nodes_visited to a default value.
+
+        :param default_val: The default value to set nodes_visited to (default is 0).
+        :type default_val: int
+
+        :return: None
+        :rtype: None
         """
         for key in self._nodes_visited.keys():
             self._nodes_visited[key] = default_val
 
     def reset_pruning(self, default_val = 0) -> None:
+        """
+        Reset the pruning count to a default value.
+
+        :param default_val: The default value to set pruning count to (default is 0).
+        :type default_val: int
+
+        :return: None
+        :rtype: None
+        """
         self._pruned = default_val
 
     def reset_nodes_in_tt(self, default_val = 0) -> None:
+        """
+        Reset the nodes in TT count to a default value.
+
+        :param default_val: The default value to set nodes in TT count to (default is 0).
+        :type default_val: int
+
+        :return: None
+        :rtype: None
+        """
         self._nodes_in_tt = default_val
 
     @property
     def pruned(self) -> int:
         """
-        xxx
+        Returns the count of pruned nodes.
+
+        :return: The count of pruned nodes.
+        :rtype: int
         """
         return self._pruned
     
     @property
     def nodes_in_tt(self) -> int:
         """
-        xxx
+        Returns the count of nodes stored in the transposition table.
+
+        :return: The count of nodes stored in the transposition table.
+        :rtype: int
         """
         return self._nodes_in_tt
     
     @property
     def nodes_visited(self) -> Dict[NodeTypes, int]:
         """
-        dda
+        Returns a dictionary containing the count of visited nodes for different node types.
+
+        :return: A dictionary containing the count of visited nodes for different node types.
+        :rtype: dict
         """
         return self._nodes_visited
 

--- a/sporkfish/zobrist_hasher.py
+++ b/sporkfish/zobrist_hasher.py
@@ -30,8 +30,8 @@ def _aggregate_piece_hash(
     board_hash: np.int64, squares: np.ndarray, colored_piece_types: np.ndarray
 ) -> np.int64:
     num_pieces = len(squares)
-    assert (
-        num_pieces == len(colored_piece_types)
+    assert num_pieces == len(
+        colored_piece_types
     ), f"Expected the same number of squares and colored_piece_types but got length {num_pieces}, {len(colored_piece_types)} respectively."
     new_board_hash = board_hash
     for idx in range(num_pieces):

--- a/tests/init_board_helper.py
+++ b/tests/init_board_helper.py
@@ -7,7 +7,6 @@ from sporkfish.searcher.move_ordering.move_order_config import (
     MoveOrderConfig,
     MoveOrderMode,
 )
-from sporkfish.searcher.move_ordering.move_orderer import MoveOrderer
 from sporkfish.searcher.searcher_config import SearcherConfig
 from sporkfish.searcher.searcher_factory import SearcherFactory
 

--- a/tests/test_move_ordering.py
+++ b/tests/test_move_ordering.py
@@ -2,9 +2,7 @@ import chess
 import pytest
 from init_board_helper import board_setup, init_board
 
-from sporkfish.searcher.move_ordering.composite_heuristic import (
-    CompositeHeuristic,
-)
+from sporkfish.searcher.move_ordering.composite_heuristic import CompositeHeuristic
 from sporkfish.searcher.move_ordering.killer_move_heuristic import KillerMoveHeuristic
 from sporkfish.searcher.move_ordering.move_orderer import MoveOrderer
 from sporkfish.searcher.move_ordering.mvv_lva_heuristic import MvvLvaHeuristic

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,19 +1,10 @@
 import pytest
-from init_board_helper import board_setup, init_board, score_fen, searcher_with_fen
+from init_board_helper import board_setup, searcher_with_fen
 
-from sporkfish.board.board_factory import BoardFactory, BoardPyChess
-from sporkfish.evaluator.evaluator_config import EvaluatorConfig, EvaluatorMode
-from sporkfish.evaluator.evaluator_factory import EvaluatorFactory
-from sporkfish.evaluator.pesto import Pesto as Evaluator
 from sporkfish.searcher.move_ordering.move_order_config import (
     MoveOrderConfig,
     MoveOrderMode,
 )
-from sporkfish.searcher.move_ordering.move_orderer import MoveOrderer
-from sporkfish.searcher.move_ordering.mvv_lva_heuristic import MvvLvaHeuristic
-from sporkfish.searcher.searcher import Searcher
-from sporkfish.searcher.searcher_config import SearcherConfig
-from sporkfish.searcher.searcher_factory import SearcherFactory
 
 
 @pytest.mark.parametrize(

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,0 +1,189 @@
+import pytest
+from init_board_helper import board_setup, init_board, score_fen, searcher_with_fen
+
+from sporkfish.board.board_factory import BoardFactory, BoardPyChess
+from sporkfish.evaluator.evaluator_config import EvaluatorConfig, EvaluatorMode
+from sporkfish.evaluator.evaluator_factory import EvaluatorFactory
+from sporkfish.evaluator.pesto import Pesto as Evaluator
+from sporkfish.searcher.move_ordering.move_order_config import (
+    MoveOrderConfig,
+    MoveOrderMode,
+)
+from sporkfish.searcher.move_ordering.move_orderer import MoveOrderer
+from sporkfish.searcher.move_ordering.mvv_lva_heuristic import MvvLvaHeuristic
+from sporkfish.searcher.searcher import Searcher
+from sporkfish.searcher.searcher_config import SearcherConfig
+from sporkfish.searcher.searcher_factory import SearcherFactory
+
+
+@pytest.mark.parametrize(
+    ("fen_string", "max_depth"),
+    [
+        (board_setup["white"]["mid"], 4),
+        (board_setup["white"]["open"], 5),
+        (board_setup["black"]["mid"], 6),
+        (board_setup["black"]["end"], 6),
+    ],
+)
+class TestPerformance:
+    """
+    Tests only for performance analysis - skipped by marked as slow
+    To run perf tests:
+    python3 -m pytest tests/test_searcher.py::TestPerformance -sv --runslow
+    """
+
+    @pytest.fixture
+    def request_fixture(self, request):
+        return request
+
+    def _run_perf_analytics(
+        self,
+        test_name: str,
+        fen: str,
+        max_depth: int,
+        enable_null_move_pruning: bool = False,
+        enable_futility_pruning: bool = False,
+        enable_delta_pruning: bool = False,
+        enable_transposition_table: bool = False,
+        enable_aspiration_windows: bool = False,
+        move_order_config: MoveOrderConfig = MoveOrderConfig(
+            move_order_mode=MoveOrderMode.MVV_LVA
+        ),
+    ) -> None:
+        import cProfile
+        import pstats
+
+        profiler = cProfile.Profile()
+        profiler.enable()
+        searcher_with_fen(
+            fen,
+            max_depth,
+            enable_null_move_pruning=enable_null_move_pruning,
+            enable_futility_pruning=enable_futility_pruning,
+            enable_delta_pruning=enable_delta_pruning,
+            enable_transposition_table=enable_transposition_table,
+            enable_aspiration_windows=enable_aspiration_windows,
+            move_order_config=move_order_config,
+        )
+        profiler.disable()
+        stats = pstats.Stats(profiler)
+
+        import os
+        import sys
+
+        test_name = (
+            test_name.replace("[", "_")
+            .replace("]", "_")
+            .replace(" ", "_")
+            .replace("/", "_")
+        )
+        perf_test_folder = "perf/"
+
+        if not os.path.exists(perf_test_folder):
+            os.mkdir(perf_test_folder)
+
+        with open(
+            os.path.join(perf_test_folder, f"{test_name}.txt"),
+            "w",
+        ) as f:
+            sys.stdout = f
+            print(
+                "------------------------------------------------------------------------------------------------"
+            )
+            print(f"FEN: {fen}")
+            stats = pstats.Stats(profiler)
+            stats.strip_dirs().sort_stats("tottime").print_stats()
+            print(
+                "------------------------------------------------------------------------------------------------"
+            )
+
+        sys.stdout = sys.__stdout__
+
+    @pytest.mark.slow
+    def test_perf_base(self, request_fixture, fen_string: str, max_depth: int) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+        )
+
+    @pytest.mark.slow
+    def test_perf_transposition_table(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_transposition_table=True,
+        )
+
+    @pytest.mark.slow
+    def test_perf_null_move_pruning(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+        )
+
+    @pytest.mark.slow
+    def test_perf_aspiration_windows(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_aspiration_windows=True,
+        )
+
+    @pytest.mark.slow
+    def test_perf_futility_pruning(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_futility_pruning=True,
+        )
+
+    @pytest.mark.slow
+    def test_perf_delta_pruning(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_delta_pruning=True,
+        )
+
+    @pytest.mark.slow
+    def test_combined_move_order(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_delta_pruning=True,
+            move_order_config=MoveOrderConfig(move_order_mode=MoveOrderMode.COMPOSITE),
+        )
+
+    @pytest.mark.slow
+    def test_perf_combined(
+        self, request_fixture, fen_string: str, max_depth: int
+    ) -> None:
+        """Performance test with combined general performance config on"""
+        self._run_perf_analytics(
+            request_fixture.node.name,
+            fen=fen_string,
+            max_depth=max_depth,
+            enable_null_move_pruning=True,
+            enable_delta_pruning=True,
+            enable_aspiration_windows=True,
+        )

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -1,7 +1,6 @@
 import pytest
 from init_board_helper import board_setup, init_board, score_fen, searcher_with_fen
 
-from sporkfish.board.board_factory import BoardFactory, BoardPyChess
 from sporkfish.evaluator.evaluator_config import EvaluatorConfig, EvaluatorMode
 from sporkfish.evaluator.evaluator_factory import EvaluatorFactory
 from sporkfish.evaluator.pesto import Pesto as Evaluator

--- a/tests/test_searcher.py
+++ b/tests/test_searcher.py
@@ -1,5 +1,5 @@
 import pytest
-from init_board_helper import board_setup, init_board, score_fen
+from init_board_helper import board_setup, init_board, score_fen, searcher_with_fen
 
 from sporkfish.board.board_factory import BoardFactory, BoardPyChess
 from sporkfish.evaluator.evaluator_config import EvaluatorConfig, EvaluatorMode
@@ -16,40 +16,12 @@ from sporkfish.searcher.searcher_config import SearcherConfig
 from sporkfish.searcher.searcher_factory import SearcherFactory
 
 
-def _evaluator(
+def evaluator(
     evaluator_cfg: EvaluatorConfig = EvaluatorConfig(
         evaluator_mode=EvaluatorMode.PESTO
     ),
 ) -> Evaluator:
     return EvaluatorFactory.create(evaluator_cfg)
-
-
-def _searcher_with_fen(
-    fen: str,
-    max_depth: int = 3,
-    enable_null_move_pruning=False,
-    enable_futility_pruning=False,
-    enable_delta_pruning=False,
-    enable_transposition_table=False,
-    enable_aspiration_windows=False,
-    move_order_config=MoveOrderConfig(move_order_mode=MoveOrderMode.MVV_LVA),
-):
-    board = BoardFactory.create(board_type=BoardPyChess)
-    s = SearcherFactory.create(
-        SearcherConfig(
-            max_depth,
-            enable_null_move_pruning=enable_null_move_pruning,
-            enable_futility_pruning=enable_futility_pruning,
-            enable_delta_pruning=enable_delta_pruning,
-            enable_transposition_table=enable_transposition_table,
-            enable_aspiration_windows=enable_aspiration_windows,
-            move_order_config=move_order_config,
-        ),
-        evaluator=_evaluator(),
-    )
-    board.set_fen(fen)
-    score, move = s.search(board)
-    return score, move
 
 
 @pytest.mark.parametrize(
@@ -66,180 +38,7 @@ class TestValidMove:
         """
         Tests if no exceptions are thrown and no null moves made
         """
-        _searcher_with_fen(fen_string)
-
-
-@pytest.mark.parametrize(
-    ("fen_string", "max_depth"),
-    [
-        (board_setup["white"]["mid"], 4),
-        (board_setup["white"]["open"], 5),
-        (board_setup["black"]["mid"], 6),
-        (board_setup["black"]["end"], 6),
-    ],
-)
-class TestPerformance:
-    """
-    Tests only for performance analysis - skipped by marked as slow
-    To run perf tests:
-    python3 -m pytest tests/test_searcher.py::TestPerformance -sv --runslow
-    """
-
-    @pytest.fixture
-    def request_fixture(self, request):
-        return request
-
-    def _run_perf_analytics(
-        self,
-        test_name: str,
-        fen: str,
-        max_depth: int,
-        enable_null_move_pruning: bool = False,
-        enable_futility_pruning: bool = False,
-        enable_delta_pruning: bool = False,
-        enable_transposition_table: bool = False,
-        enable_aspiration_windows: bool = False,
-        move_order_config: MoveOrderConfig = MoveOrderConfig(
-            move_order_mode=MoveOrderMode.MVV_LVA
-        ),
-    ) -> None:
-        import cProfile
-        import pstats
-
-        profiler = cProfile.Profile()
-        profiler.enable()
-        _searcher_with_fen(
-            fen,
-            max_depth,
-            enable_null_move_pruning=enable_null_move_pruning,
-            enable_futility_pruning=enable_futility_pruning,
-            enable_delta_pruning=enable_delta_pruning,
-            enable_transposition_table=enable_transposition_table,
-            enable_aspiration_windows=enable_aspiration_windows,
-            move_order_config=move_order_config,
-        )
-        profiler.disable()
-        stats = pstats.Stats(profiler)
-
-        import os
-        import sys
-
-        test_name = (
-            test_name.replace("[", "_")
-            .replace("]", "_")
-            .replace(" ", "_")
-            .replace("/", "_")
-        )
-        perf_test_folder = "perf/"
-
-        if not os.path.exists(perf_test_folder):
-            os.mkdir(perf_test_folder)
-
-        with open(
-            os.path.join(perf_test_folder, f"{test_name}.txt"),
-            "w",
-        ) as f:
-            sys.stdout = f
-            print(
-                "------------------------------------------------------------------------------------------------"
-            )
-            print(f"FEN: {fen}")
-            stats = pstats.Stats(profiler)
-            stats.strip_dirs().sort_stats("tottime").print_stats()
-            print(
-                "------------------------------------------------------------------------------------------------"
-            )
-
-        sys.stdout = sys.__stdout__
-
-    @pytest.mark.slow
-    def test_perf_base(self, request_fixture, fen_string: str, max_depth: int) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-        )
-
-    @pytest.mark.slow
-    def test_perf_transposition_table(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_transposition_table=True,
-        )
-
-    @pytest.mark.slow
-    def test_perf_null_move_pruning(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-        )
-
-    @pytest.mark.slow
-    def test_perf_aspiration_windows(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_aspiration_windows=True,
-        )
-
-    @pytest.mark.slow
-    def test_perf_futility_pruning(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_futility_pruning=True,
-        )
-
-    @pytest.mark.slow
-    def test_perf_delta_pruning(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_delta_pruning=True,
-        )
-
-    @pytest.mark.slow
-    def test_combined_move_order(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_delta_pruning=True,
-            move_order_config=MoveOrderConfig(move_order_mode=MoveOrderMode.COMPOSITE),
-        )
-
-    @pytest.mark.slow
-    def test_perf_combined(
-        self, request_fixture, fen_string: str, max_depth: int
-    ) -> None:
-        """Performance test with combined general performance config on"""
-        self._run_perf_analytics(
-            request_fixture.node.name,
-            fen=fen_string,
-            max_depth=max_depth,
-            enable_null_move_pruning=True,
-            enable_delta_pruning=True,
-            enable_aspiration_windows=True,
-        )
+        searcher_with_fen(fen_string)
 
 
 @pytest.mark.parametrize(
@@ -268,8 +67,8 @@ class TestConsistency:
         enable_transposition_table: bool = False,
         enable_aspiration_windows: bool = False,
     ):
-        score, move = _searcher_with_fen(fen, max_depth)
-        score_2, move_2 = _searcher_with_fen(
+        score, move = searcher_with_fen(fen, max_depth)
+        score_2, move_2 = searcher_with_fen(
             fen,
             max_depth,
             enable_null_move_pruning=enable_null_move_pruning,
@@ -383,7 +182,7 @@ def _init_searcher(
             max_depth,
             move_order_config=MoveOrderConfig(move_order_mode=move_order_mode),
         ),
-        evaluator=_evaluator(),
+        evaluator=evaluator(),
     )
 
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,6 +1,7 @@
 import pytest
 
-from sporkfish.statistics import Statistics, NodeTypes
+from sporkfish.statistics import NodeTypes, Statistics
+
 
 class TestIncrementStatistics:
     def test_increment_node_visited(self):
@@ -8,7 +9,7 @@ class TestIncrementStatistics:
         for k, v in S.nodes_visited.items():
             assert v == 0
             S.increment_node_visited(k)
-        
+
         for k, v in S.nodes_visited.items():
             assert v == 1
 
@@ -20,9 +21,10 @@ class TestIncrementStatistics:
 
     def test_increment_nodes_in_tt(self):
         S = Statistics()
-        assert S.nodes_in_tt == 0
-        S.increment_nodes_in_tt()
-        assert S.nodes_in_tt == 1
+        assert S.nodes_from_tt == 0
+        S.increment_nodes_from_tt()
+        assert S.nodes_from_tt == 1
+
 
 class TestResetStatistics:
     def test_reset_node_visited(self):
@@ -31,7 +33,7 @@ class TestResetStatistics:
             assert v == 0
             S.increment_node_visited(k, 3)
             assert S.nodes_visited[k] == 3
-        
+
         S.reset_node_visited()
         for k, v in S.nodes_visited.items():
             assert v == 0
@@ -46,8 +48,8 @@ class TestResetStatistics:
 
     def test_reset_nodes_in_tt(self):
         S = Statistics()
-        assert S.nodes_in_tt == 0
-        S.increment_nodes_in_tt(32)
-        assert S.nodes_in_tt == 32
-        S.reset_nodes_in_tt(0)
-        assert S.nodes_in_tt == 0
+        assert S.nodes_from_tt == 0
+        S.increment_nodes_from_tt(32)
+        assert S.nodes_from_tt == 32
+        S.reset_nodes_from_tt(0)
+        assert S.nodes_from_tt == 0

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,7 +1,7 @@
-import pytest
 
-from sporkfish.statistics import NodeTypes, Statistics
+from sporkfish.statistics import Statistics
 
+# TODO: add tests to check searcher is indeed incrementing statistics correctly
 
 class TestIncrementStatistics:
     def test_increment_node_visited(self):

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,53 @@
+import pytest
+
+from sporkfish.statistics import Statistics, NodeTypes
+
+class TestIncrementStatistics:
+    def test_increment_node_visited(self):
+        S = Statistics()
+        for k, v in S.nodes_visited.items():
+            assert v == 0
+            S.increment_node_visited(k)
+        
+        for k, v in S.nodes_visited.items():
+            assert v == 1
+
+    def test_increment_pruning(self):
+        S = Statistics()
+        assert S.pruned == 0
+        S.increment_pruning()
+        assert S.pruned == 1
+
+    def test_increment_nodes_in_tt(self):
+        S = Statistics()
+        assert S.nodes_in_tt == 0
+        S.increment_nodes_in_tt()
+        assert S.nodes_in_tt == 1
+
+class TestResetStatistics:
+    def test_reset_node_visited(self):
+        S = Statistics()
+        for k, v in S.nodes_visited.items():
+            assert v == 0
+            S.increment_node_visited(k, 3)
+            assert S.nodes_visited[k] == 3
+        
+        S.reset_node_visited()
+        for k, v in S.nodes_visited.items():
+            assert v == 0
+
+    def test_reset_pruning(self):
+        S = Statistics()
+        assert S.pruned == 0
+        S.increment_pruning(3)
+        assert S.pruned == 3
+        S.reset_pruning(0)
+        assert S.pruned == 0
+
+    def test_reset_nodes_in_tt(self):
+        S = Statistics()
+        assert S.nodes_in_tt == 0
+        S.increment_nodes_in_tt(32)
+        assert S.nodes_in_tt == 32
+        S.reset_nodes_in_tt(0)
+        assert S.nodes_in_tt == 0


### PR DESCRIPTION
### Change:
- Record different types of nodes visited
- Record number of pruning's that took place
- Record number of times when TT was used to return node score
- Added trivial unit tests for statistics behaviour

Ideally would like to also:
- record different types of pruning's, and
- add more tests, specifically checking if the searcher is indeed incrementing the statistics accurately

can decide later if we want to do in this PR.

### Context: 
Previously, the statistics class only records number of nodes visited, and did not distinguish between the nature of the nodes. For performance and (more generally) behavioural analysis, we would like to be able to record:
- different types of nodes visited
- number of prunings that took place
- number of times when TT was used to return node score

See #99 for more background